### PR TITLE
Update cmdlets and tests to handle legacy workspaces properly

### DIFF
--- a/src/Modules/Profile/Commands.Profile.Test/ConnectPowerBIServiceAccountTests.cs
+++ b/src/Modules/Profile/Commands.Profile.Test/ConnectPowerBIServiceAccountTests.cs
@@ -20,21 +20,25 @@ namespace Microsoft.PowerBI.Commands.Profile.Test
             using (var ps = System.Management.Automation.PowerShell.Create())
             {
                 ps.AddCommand(ProfileTestUtilities.ConnectPowerBIServiceAccountCmdletInfo);
-                var result = ps.Invoke();
+
+                var results = ps.Invoke();
+
                 TestUtilities.AssertNoCmdletErrors(ps);
-                Assert.IsTrue(result.Count == 1);
-                Assert.IsTrue(result[0].BaseObject is PowerBIProfile);
-                var profile = result[0].BaseObject as PowerBIProfile;
+                Assert.IsTrue(results.Count == 1);
+                Assert.IsTrue(results[0].BaseObject is PowerBIProfile);
+                var profile = results[0].BaseObject as PowerBIProfile;
                 Assert.IsNotNull(profile.Environment);
                 Assert.IsNotNull(profile.UserName);
                 Assert.IsNotNull(profile.TenantId);
 
                 ps.Commands.Clear();
                 ps.AddCommand(ProfileTestUtilities.DisconnectPowerBIServiceAccountCmdletInfo);
-                result = ps.Invoke();
-                Assert.IsNotNull(result);
-                Assert.AreEqual(0, result.Count);
+
+                results = ps.Invoke();
+
                 TestUtilities.AssertNoCmdletErrors(ps);
+                Assert.IsNotNull(results);
+                Assert.AreEqual(0, results.Count);
             }
         }
     }

--- a/src/Modules/Profile/Commands.Profile.Test/ConnectPowerBIServiceAccountTests.cs
+++ b/src/Modules/Profile/Commands.Profile.Test/ConnectPowerBIServiceAccountTests.cs
@@ -3,12 +3,8 @@
  * Licensed under the MIT License.
  */
 
-using System.Management.Automation;
 using Microsoft.PowerBI.Common.Abstractions;
-using Microsoft.PowerBI.Common.Abstractions.Interfaces;
-using Microsoft.PowerBI.Commands.Profile;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Diagnostics.CodeAnalysis;
 using Commands.Common.Test;
 
 namespace Microsoft.PowerBI.Commands.Profile.Test
@@ -32,6 +28,13 @@ namespace Microsoft.PowerBI.Commands.Profile.Test
                 Assert.IsNotNull(profile.Environment);
                 Assert.IsNotNull(profile.UserName);
                 Assert.IsNotNull(profile.TenantId);
+
+                ps.Commands.Clear();
+                ps.AddCommand(ProfileTestUtilities.DisconnectPowerBIServiceAccountCmdletInfo);
+                result = ps.Invoke();
+                Assert.IsNotNull(result);
+                Assert.AreEqual(0, result.Count);
+                TestUtilities.AssertNoCmdletErrors(ps);
             }
         }
     }

--- a/src/Modules/Profile/Commands.Profile.Test/DisconnectPowerBIServiceAccountTests.cs
+++ b/src/Modules/Profile/Commands.Profile.Test/DisconnectPowerBIServiceAccountTests.cs
@@ -3,12 +3,7 @@
  * Licensed under the MIT License.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Management.Automation;
-using System.Text;
 using Commands.Common.Test;
-using Microsoft.PowerBI.Commands.Common;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.PowerBI.Commands.Profile.Test

--- a/src/Modules/Profile/Commands.Profile.Test/DisconnectPowerBIServiceAccountTests.cs
+++ b/src/Modules/Profile/Commands.Profile.Test/DisconnectPowerBIServiceAccountTests.cs
@@ -19,10 +19,12 @@ namespace Microsoft.PowerBI.Commands.Profile.Test
             using (var ps = System.Management.Automation.PowerShell.Create())
             {
                 ps.AddCommand(ProfileTestUtilities.DisconnectPowerBIServiceAccountCmdletInfo);
-                var result = ps.Invoke();
-                Assert.IsNotNull(result);
-                Assert.AreEqual(0, result.Count);
+
+                var results = ps.Invoke();
+
                 TestUtilities.AssertNoCmdletErrors(ps);
+                Assert.IsNotNull(results);
+                Assert.AreEqual(0, results.Count);
             }
         }
     }

--- a/src/Modules/Profile/Commands.Profile.Test/ProfileTestUtilities.cs
+++ b/src/Modules/Profile/Commands.Profile.Test/ProfileTestUtilities.cs
@@ -20,7 +20,7 @@ namespace Microsoft.PowerBI.Commands.Profile.Test
 
         public static void ConnectToPowerBI(System.Management.Automation.PowerShell ps, string environment = null)
         {
-            if(string.IsNullOrEmpty(environment))
+            if (string.IsNullOrEmpty(environment))
             {
 #if DEBUG
                 environment = nameof(PowerBIEnvironmentType.OneBox);
@@ -30,7 +30,9 @@ namespace Microsoft.PowerBI.Commands.Profile.Test
             }
 
             ps.AddCommand(ConnectPowerBIServiceAccountCmdletInfo).AddParameter(nameof(ConnectPowerBIServiceAccount.Environment), environment);
+
             var result = ps.Invoke();
+
             TestUtilities.AssertNoCmdletErrors(ps);
             Assert.IsNotNull(result);
             ps.Commands.Clear();
@@ -39,7 +41,9 @@ namespace Microsoft.PowerBI.Commands.Profile.Test
         public static void DisconnectToPowerBI(System.Management.Automation.PowerShell ps)
         {
             ps.AddCommand(DisconnectPowerBIServiceAccountCmdletInfo);
+
             var result = ps.Invoke();
+
             TestUtilities.AssertNoCmdletErrors(ps);
             Assert.IsNotNull(result);
             Assert.AreEqual(0, result.Count);

--- a/src/Modules/Reports/Commands.Reports.Test/GetPowerBIReportTests.cs
+++ b/src/Modules/Reports/Commands.Reports.Test/GetPowerBIReportTests.cs
@@ -5,6 +5,7 @@
 
 using System.Linq;
 using System.Management.Automation;
+using Commands.Common.Test;
 using Microsoft.PowerBI.Commands.Profile.Test;
 using Microsoft.PowerBI.Commands.Reports;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -29,6 +30,7 @@ namespace Commands.Reports.Test
 
                 var results = ps.Invoke();
 
+                TestUtilities.AssertNoCmdletErrors(ps);
                 Assert.IsNotNull(results);
                 if (!results.Any())
                 {

--- a/src/Modules/Workspaces/Commands.Workspaces.Test/AddPowerBIWorkspaceUserTest.cs
+++ b/src/Modules/Workspaces/Commands.Workspaces.Test/AddPowerBIWorkspaceUserTest.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
+using Commands.Common.Test;
 using Microsoft.PowerBI.Commands.Profile.Test;
 using Microsoft.PowerBI.Common.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -40,6 +41,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
 
                 var results = ps.Invoke();
 
+                TestUtilities.AssertNoCmdletErrors(ps);
                 Assert.IsNotNull(results);
                 Assert.IsTrue(results.Any());
             }
@@ -71,6 +73,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
 
                 var results = ps.Invoke();
 
+                TestUtilities.AssertNoCmdletErrors(ps);
                 Assert.IsNotNull(results);
                 Assert.IsTrue(results.Any());
             }

--- a/src/Modules/Workspaces/Commands.Workspaces.Test/GetPowerBIWorkspaceTests.cs
+++ b/src/Modules/Workspaces/Commands.Workspaces.Test/GetPowerBIWorkspaceTests.cs
@@ -69,6 +69,66 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        public void EndToEndGetWorkspacesOrganizationScopeAndFirst()
+        {
+            /*
+             * Test requires at least one workspace (group or preview workspace) and login as an administrator
+             */
+            using (var ps = System.Management.Automation.PowerShell.Create())
+            {
+                ProfileTestUtilities.ConnectToPowerBI(ps);
+                var parameters = new Dictionary<string, object>()
+                    {
+                        { nameof(GetPowerBIWorkspace.Scope), PowerBIUserScope.Organization },
+                        { nameof(GetPowerBIWorkspace.First), 1 }
+                    };
+                ps.AddCommand(WorkspacesTestUtilities.GetPowerBIWorkspaceCmdletInfo).AddParameters(parameters);
+
+                var results = ps.Invoke();
+
+                TestUtilities.AssertNoCmdletErrors(ps);
+                Assert.IsNotNull(results);
+                if (!results.Any())
+                {
+                    Assert.Inconclusive("No workspaces returned. Verify you have workspaces in your organization.");
+                }
+                Assert.AreEqual(1, results.Count);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("Interactive")]
+        [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        public void EndToEndGetWorkspacesIndividualScopeAndFirst()
+        {
+            /*
+             * Test requires at least one workspace (group or preview workspace)
+             */
+            using (var ps = System.Management.Automation.PowerShell.Create())
+            {
+                ProfileTestUtilities.ConnectToPowerBI(ps);
+                var parameters = new Dictionary<string, object>()
+                    {
+                        { nameof(GetPowerBIWorkspace.Scope), PowerBIUserScope.Individual },
+                        { nameof(GetPowerBIWorkspace.First), 1 }
+                    };
+                ps.AddCommand(WorkspacesTestUtilities.GetPowerBIWorkspaceCmdletInfo).AddParameters(parameters);
+
+                var results = ps.Invoke();
+
+                TestUtilities.AssertNoCmdletErrors(ps);
+                Assert.IsNotNull(results);
+                if (!results.Any())
+                {
+                    Assert.Inconclusive("No workspaces returned. Verify you are assigned or own any workspaces.");
+                }
+                Assert.AreEqual(1, results.Count);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("Interactive")]
+        [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
         public void EndToEndGetWorkspacesOrganizationScopeAndFilter()
         {
             /*
@@ -84,6 +144,46 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
                 var parameters = new Dictionary<string, object>()
                     {
                         { nameof(GetPowerBIWorkspace.Scope), PowerBIUserScope.Organization },
+                        { nameof(GetPowerBIWorkspace.Filter), filterQuery }
+                    };
+                ps.AddCommand(WorkspacesTestUtilities.GetPowerBIWorkspaceCmdletInfo).AddParameters(parameters);
+
+                var results = ps.Invoke();
+
+                TestUtilities.AssertNoCmdletErrors(ps);
+                Assert.IsNotNull(results);
+                Assert.IsTrue(results.Any());
+                ps.Commands.Clear();
+
+                parameters[nameof(GetPowerBIWorkspace.Filter)] = string.Format("name eq '{0}'", TestUtilities.GetRandomString());
+                ps.AddCommand(WorkspacesTestUtilities.GetPowerBIWorkspaceCmdletInfo).AddParameters(parameters);
+
+                results = ps.Invoke();
+
+                TestUtilities.AssertNoCmdletErrors(ps);
+                Assert.IsNotNull(results);
+                Assert.IsFalse(results.Any());
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("Interactive")]
+        [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        public void EndToEndGetWorkspacesIndividualScopeAndFilter()
+        {
+            /*
+             * Test requires at least one workspace (group or preview workspace) and login as an administrator
+             */
+            using (var ps = System.Management.Automation.PowerShell.Create())
+            {
+                ProfileTestUtilities.ConnectToPowerBI(ps);
+                var workspace = WorkspacesTestUtilities.GetFirstWorkspace(ps, PowerBIUserScope.Individual);
+                WorkspacesTestUtilities.AssertShouldContinueIndividualTest(workspace);
+
+                var filterQuery = string.Format("name eq '{0}'", workspace.Name);
+                var parameters = new Dictionary<string, object>()
+                    {
+                        { nameof(GetPowerBIWorkspace.Scope), PowerBIUserScope.Individual },
                         { nameof(GetPowerBIWorkspace.Filter), filterQuery }
                     };
                 ps.AddCommand(WorkspacesTestUtilities.GetPowerBIWorkspaceCmdletInfo).AddParameters(parameters);

--- a/src/Modules/Workspaces/Commands.Workspaces.Test/RemovePowerBIWorkspaceUserTests.cs
+++ b/src/Modules/Workspaces/Commands.Workspaces.Test/RemovePowerBIWorkspaceUserTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
+using Commands.Common.Test;
 using Microsoft.PowerBI.Commands.Profile.Test;
 using Microsoft.PowerBI.Common.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -39,6 +40,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
 
                 var results = ps.Invoke();
 
+                TestUtilities.AssertNoCmdletErrors(ps);
                 Assert.IsNotNull(results);
                 Assert.IsTrue(results.Any());
             }
@@ -68,6 +70,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
 
                 var results = ps.Invoke();
 
+                TestUtilities.AssertNoCmdletErrors(ps);
                 Assert.IsNotNull(results);
                 Assert.IsTrue(results.Any());
             }

--- a/src/Modules/Workspaces/Commands.Workspaces.Test/SetPowerBIWorkspaceTests.cs
+++ b/src/Modules/Workspaces/Commands.Workspaces.Test/SetPowerBIWorkspaceTests.cs
@@ -43,6 +43,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
 
                 var results = ps.Invoke();
 
+                TestUtilities.AssertNoCmdletErrors(ps);
                 Assert.IsNotNull(results);
                 var updatedWorkspace = WorkspacesTestUtilities.GetWorkspace(ps, PowerBIUserScope.Organization, workspace.Id);
                 Assert.AreEqual(updatedName, updatedWorkspace.Name);
@@ -74,6 +75,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
 
                 var results = ps.Invoke();
 
+                TestUtilities.AssertNoCmdletErrors(ps);
                 Assert.IsNotNull(results);
                 var updatedWorkspace = WorkspacesTestUtilities.GetWorkspace(ps, PowerBIUserScope.Organization, workspace.Id);
                 Assert.AreEqual(updatedName, updatedWorkspace.Name);

--- a/src/Modules/Workspaces/Commands.Workspaces.Test/SetPowerBIWorkspaceTests.cs
+++ b/src/Modules/Workspaces/Commands.Workspaces.Test/SetPowerBIWorkspaceTests.cs
@@ -27,29 +27,24 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
             using (var ps = System.Management.Automation.PowerShell.Create())
             {
                 ProfileTestUtilities.ConnectToPowerBI(ps);
-
-                var workspace = WorkspacesTestUtilities.GetWorkspace(ps, scope: PowerBIUserScope.Organization);
-                if (workspace == null)
-                {
-                    Assert.Inconclusive("No workspaces found to perform end to end test");
-                }
+                var workspace = WorkspacesTestUtilities.GetFirstWorkspaceInOrganization(ps);
+                WorkspacesTestUtilities.AssertShouldContinueOrganizationTest(workspace);
 
                 var updatedName = TestUtilities.GetRandomString();
                 var updatedDescription = TestUtilities.GetRandomString();
                 var parameters = new Dictionary<string, object>
                 {
-                    { "Scope", PowerBIUserScope.Organization },
-                    { "Id", workspace.Id },
-                    { "Name", updatedName },
-                    { "Description", updatedDescription },
+                    { nameof(SetPowerBIWorkspace.Scope), PowerBIUserScope.Organization },
+                    { nameof(SetPowerBIWorkspace.Id), workspace.Id },
+                    { nameof(SetPowerBIWorkspace.Name), updatedName },
+                    { nameof(SetPowerBIWorkspace.Description), updatedDescription },
                 };
                 ps.AddCommand(Cmdlet).AddParameters(parameters);
 
-                var result = ps.Invoke();
-                ps.Commands.Clear();
+                var results = ps.Invoke();
 
-                Assert.IsNotNull(result);
-                var updatedWorkspace = WorkspacesTestUtilities.GetWorkspace(ps, workspace.Id, PowerBIUserScope.Organization);
+                Assert.IsNotNull(results);
+                var updatedWorkspace = WorkspacesTestUtilities.GetWorkspace(ps, PowerBIUserScope.Organization, workspace.Id);
                 Assert.AreEqual(updatedName, updatedWorkspace.Name);
                 Assert.AreEqual(updatedDescription, updatedWorkspace.Description);
             }
@@ -63,12 +58,8 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
             using (var ps = System.Management.Automation.PowerShell.Create())
             {
                 ProfileTestUtilities.ConnectToPowerBI(ps);
-
-                var workspace = WorkspacesTestUtilities.GetWorkspace(ps, scope: PowerBIUserScope.Organization);
-                if (workspace == null)
-                {
-                    Assert.Inconclusive("No workspaces found to perform end to end test");
-                }
+                var workspace = WorkspacesTestUtilities.GetFirstWorkspaceInOrganization(ps);
+                WorkspacesTestUtilities.AssertShouldContinueOrganizationTest(workspace);
 
                 var updatedName = TestUtilities.GetRandomString();
                 var updatedDescription = TestUtilities.GetRandomString();
@@ -76,16 +67,15 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
                 workspace.Description = updatedDescription;
                 var parameters = new Dictionary<string, object>
                 {
-                    { "Scope", PowerBIUserScope.Organization },
-                    { "Workspace", workspace },
+                    { nameof(SetPowerBIWorkspace.Scope), PowerBIUserScope.Organization },
+                    { nameof(SetPowerBIWorkspace.Workspace), workspace }
                 };
                 ps.AddCommand(Cmdlet).AddParameters(parameters);
 
-                var result = ps.Invoke();
-                ps.Commands.Clear();
+                var results = ps.Invoke();
 
-                Assert.IsNotNull(result);
-                var updatedWorkspace = WorkspacesTestUtilities.GetWorkspace(ps, workspace.Id, PowerBIUserScope.Organization);
+                Assert.IsNotNull(results);
+                var updatedWorkspace = WorkspacesTestUtilities.GetWorkspace(ps, PowerBIUserScope.Organization, workspace.Id);
                 Assert.AreEqual(updatedName, updatedWorkspace.Name);
                 Assert.AreEqual(updatedDescription, updatedWorkspace.Description);
             }
@@ -99,12 +89,11 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
             using (var ps = System.Management.Automation.PowerShell.Create())
             {
                 ProfileTestUtilities.ConnectToPowerBI(ps);
+
                 var parameters = new Dictionary<string, object>
                 {
-                    { "Scope", PowerBIUserScope.Individual },
-                    { "Id", new Guid() },
-                    { "Name", "Updated Workspace Name" },
-                    { "Description", "Updated Workspace Description" },
+                    { nameof(SetPowerBIWorkspace.Scope), PowerBIUserScope.Individual },
+                    { nameof(SetPowerBIWorkspace.Workspace), new Group() }
                 };
                 ps.AddCommand(Cmdlet).AddParameters(parameters);
 
@@ -129,7 +118,11 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
             {
                 ProfileTestUtilities.SafeDisconnectFromPowerBI(ps);
 
-                var parameters = new Dictionary<string, object> { { "Id", new Guid() } };
+                var parameters = new Dictionary<string, object>
+                {
+                    { nameof(SetPowerBIWorkspace.Scope), PowerBIUserScope.Organization },
+                    { nameof(SetPowerBIWorkspace.Workspace), new Group() }
+                };
                 ps.AddCommand(Cmdlet).AddParameters(parameters);
 
                 ps.Invoke();
@@ -144,9 +137,10 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         {
             using (var ps = System.Management.Automation.PowerShell.Create())
             {
-                ps.AddCommand(Cmdlet);
+                ps.AddCommand(Cmdlet)
+                    .AddParameter(nameof(GetPowerBIWorkspace.Scope), PowerBIUserScope.Organization);
 
-                var result = ps.Invoke();
+                var results = ps.Invoke();
 
                 Assert.Fail("Should not have reached this point");
             }
@@ -160,13 +154,13 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
             {
                 var parameters = new Dictionary<string, object>
                 {
-                    { "Scope", PowerBIUserScope.Organization },
-                    { "Id", new Guid() },
-                    { "Workspace", new Group() }
+                    { nameof(SetPowerBIWorkspace.Scope), PowerBIUserScope.Organization },
+                    { nameof(SetPowerBIWorkspace.Id), new Guid() },
+                    { nameof(SetPowerBIWorkspace.Workspace), new Group() }
                 };
                 ps.AddCommand(Cmdlet).AddParameters(parameters);
 
-                var result = ps.Invoke();
+                var results = ps.Invoke();
 
                 Assert.Fail("Should not have reached this point");
             }

--- a/src/Modules/Workspaces/Commands.Workspaces.Test/WorkspacesTestUtilities.cs
+++ b/src/Modules/Workspaces/Commands.Workspaces.Test/WorkspacesTestUtilities.cs
@@ -87,7 +87,9 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         {
             ps.Commands.Clear();
             ps.AddCommand(GetPowerBIWorkspaceCmdletInfo).AddParameter(nameof(GetPowerBIWorkspace.Scope), scope.ToString());
+
             var results = ps.Invoke();
+
             TestUtilities.AssertNoCmdletErrors(ps);
             ps.Commands.Clear();
             return results;

--- a/src/Modules/Workspaces/Commands.Workspaces.Test/WorkspacesTestUtilities.cs
+++ b/src/Modules/Workspaces/Commands.Workspaces.Test/WorkspacesTestUtilities.cs
@@ -3,33 +3,94 @@
  * Licensed under the MIT License.
  */
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
 using Commands.Common.Test;
 using Microsoft.PowerBI.Api.V2.Models;
 using Microsoft.PowerBI.Common.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.PowerBI.Commands.Workspaces.Test
 {
     public static class WorkspacesTestUtilities
     {
-        public static CmdletInfo GetPowerBIWorkspaceCmdletInfo { get; } = new CmdletInfo($"{GetPowerBIWorkspace.CmdletVerb}-{GetPowerBIWorkspace.CmdletName}", typeof(GetPowerBIWorkspace));
+        public static CmdletInfo GetPowerBIWorkspaceCmdletInfo => new CmdletInfo($"{GetPowerBIWorkspace.CmdletVerb}-{GetPowerBIWorkspace.CmdletName}", typeof(GetPowerBIWorkspace));
 
-        public static Group GetWorkspace(System.Management.Automation.PowerShell ps, string id = null, PowerBIUserScope scope = PowerBIUserScope.Individual)
+        public static void AssertShouldContinueOrganizationTest(Group workspace)
         {
+            if (workspace == null)
+            {
+                Assert.Inconclusive("No workspaces returned. Verify you have workspaces in your organization.");
+            }
+        }
+
+        public static void AssertShouldContinueIndividualTest(Group workspace)
+        {
+            if (workspace == null)
+            {
+                Assert.Inconclusive("No workspaces returned. Verify you are assigned or own any workspaces.");
+            }
+        }
+
+        public static Group GetWorkspace(System.Management.Automation.PowerShell ps, PowerBIUserScope scope, string id)
+        {
+            var results = InvokeGetPowerBIWorkspace(ps, scope);
+            if (results.Any())
+            {
+                var workspaces = results.Select(x => (Group)x.BaseObject);
+                return workspaces.First(x => x.Id == id);
+            }
+
+            return null;
+        }
+
+        public static Group GetFirstWorkspace(System.Management.Automation.PowerShell ps, PowerBIUserScope scope)
+        {
+            var results = InvokeGetPowerBIWorkspace(ps, scope);
+            if (results.Any())
+            {
+                var workspaces = results.Select(x => (Group)x.BaseObject);
+                return workspaces.First();
+            }
+
+            return null;
+        }
+
+        // TODO: Until the non-admin endpoint exposes type, this can only call the cmdlet with Organization scope
+        public static Group GetFirstWorkspaceInOrganization(System.Management.Automation.PowerShell ps)
+        {
+            var results = InvokeGetPowerBIWorkspace(ps, PowerBIUserScope.Organization);
+            if (results.Any())
+            {
+                var workspaces = results.Select(x => (Group)x.BaseObject);
+                return workspaces.FirstOrDefault(x => x.Type == WorkspaceType.Workspace);
+            }
+
+            return null;
+        }
+
+        // TODO: Until the non-admin endpoint supports users, this can only call the cmdlet with Organization scope
+        public static Group GetFirstWorkspaceWithUsersInOrganization(System.Management.Automation.PowerShell ps)
+        {
+            var results = InvokeGetPowerBIWorkspace(ps, PowerBIUserScope.Organization);
+            if (results.Any())
+            {
+                var workspaces = results.Select(x => (Group)x.BaseObject);
+                return workspaces.FirstOrDefault(x => x.Type == WorkspaceType.Workspace && x.Users.Any());
+            }
+
+            return null;
+        }
+
+        private static ICollection<PSObject> InvokeGetPowerBIWorkspace(System.Management.Automation.PowerShell ps, PowerBIUserScope scope)
+        {
+            ps.Commands.Clear();
             ps.AddCommand(GetPowerBIWorkspaceCmdletInfo).AddParameter(nameof(GetPowerBIWorkspace.Scope), scope.ToString());
             var results = ps.Invoke();
             TestUtilities.AssertNoCmdletErrors(ps);
             ps.Commands.Clear();
-
-            if (results.Any())
-            {
-                var workspaces = results.Select(x => (Group)x.BaseObject);
-
-                return id == null ? workspaces.First() : workspaces.First(x => x.Id == id);
-            }
-
-            return null;
+            return results;
         }
     }
 }

--- a/src/Modules/Workspaces/Commands.Workspaces/GetPowerBIWorkspace.cs
+++ b/src/Modules/Workspaces/Commands.Workspaces/GetPowerBIWorkspace.cs
@@ -66,11 +66,6 @@ namespace Microsoft.PowerBI.Commands.Workspaces
         {
             base.BeginProcessing();
 
-            if(!string.IsNullOrEmpty(this.Filter) && this.Scope.Equals(PowerBIUserScope.Individual))
-            {
-                this.Logger.ThrowTerminatingError($"{nameof(this.Filter)} is only applied when -{nameof(this.Scope)} is set to {nameof(PowerBIUserScope.Organization)}");
-            }
-
             if (!string.IsNullOrEmpty(this.User) && this.Scope.Equals(PowerBIUserScope.Individual))
             {
                 this.Logger.ThrowTerminatingError($"{nameof(this.User)} is only applied when -{nameof(this.Scope)} is set to {nameof(PowerBIUserScope.Organization)}");
@@ -92,12 +87,12 @@ namespace Microsoft.PowerBI.Commands.Workspaces
                 this.Filter = string.IsNullOrEmpty(this.Filter) ? OrphanedFilterString : $"({this.Filter}) and ({OrphanedFilterString})";
             }
 
-            if(this.ParameterSetName == IdParameterSetName && this.Scope == PowerBIUserScope.Organization)
+            if(this.ParameterSetName == IdParameterSetName)
             {
                 this.Filter = $"id eq '{this.Id}'";
             }
 
-            if (this.ParameterSetName == NameParameterSetName && this.Scope == PowerBIUserScope.Organization)
+            if (this.ParameterSetName == NameParameterSetName)
             {
                 this.Filter = $"tolower(name) eq '{this.Name.ToLower()}'";
             }
@@ -109,37 +104,9 @@ namespace Microsoft.PowerBI.Commands.Workspaces
             }
 
             var workspacesResult = this.Scope == PowerBIUserScope.Individual ? 
-                client.Groups.GetGroups() : 
+                client.Groups.GetGroups(filter: this.Filter, top: this.First, skip: this.Skip) : 
                 client.Groups.GetGroupsAsAdmin(expand: "users", filter: this.Filter, top: this.First, skip: this.Skip);
             var workspaces = workspacesResult.Value;
-            if (this.Scope == PowerBIUserScope.Individual)
-            {
-                // non-Admin API doesn't support filter, top, skip; processing after getting result
-                if (this.Id != default)
-                {
-                    workspaces = workspaces.Where(w => this.Id == new Guid(w.Id)).ToList();
-                }
-
-                if(!string.IsNullOrEmpty(this.Name))
-                {
-                    workspaces = workspaces.Where(w => this.Name.Equals(w.Name, StringComparison.OrdinalIgnoreCase)).ToList();
-                }
-
-                if (this.Skip.GetValueOrDefault() > 0)
-                {
-                    workspaces = workspaces.Skip(this.Skip.Value).ToList();
-                }
-
-                if (this.First.GetValueOrDefault() > 0)
-                {
-                    workspaces = workspaces.Take(this.First.Value).ToList();
-                }
-            }
-
-            if(this.Scope == PowerBIUserScope.Organization)
-            {
-                this.Logger.WriteWarning($"Only preview workspaces are returned when -{nameof(this.Scope)} {nameof(PowerBIUserScope.Organization)} is specified");
-            }
 
             this.Logger.WriteObject(workspaces, true);
         }

--- a/src/Modules/Workspaces/Commands.Workspaces/GetPowerBIWorkspace.cs
+++ b/src/Modules/Workspaces/Commands.Workspaces/GetPowerBIWorkspace.cs
@@ -5,15 +5,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Management.Automation;
 using Microsoft.PowerBI.Api.V2;
 using Microsoft.PowerBI.Api.V2.Models;
-using Microsoft.PowerBI.Commands.Common;
 using Microsoft.PowerBI.Common.Abstractions;
 using Microsoft.PowerBI.Common.Abstractions.Interfaces;
 using Microsoft.PowerBI.Common.Client;
-using Microsoft.Rest;
 
 namespace Microsoft.PowerBI.Commands.Workspaces
 {
@@ -29,6 +26,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces
         private const string NameParameterSetName = "Name";
         private const string ListParameterSetName = "List";
 
+        // Since internally, users are null rather than an empty list on workspaces v1 (groups), we don't need to filter on type for the time being
         private const string OrphanedFilterString = "(not users/any()) or (not users/any(u: u/groupUserAccessRight eq Microsoft.PowerBI.ServiceContracts.Api.GroupUserAccessRight'Admin'))";
 
         #region Parameters

--- a/src/Modules/Workspaces/Commands.Workspaces/SetPowerBIWorkspace.cs
+++ b/src/Modules/Workspaces/Commands.Workspaces/SetPowerBIWorkspace.cs
@@ -67,6 +67,8 @@ namespace Microsoft.PowerBI.Commands.Workspaces
             }
             else if (this.ParameterSetName.Equals(WorkspaceParameterSetName))
             {
+                // The API will throw 400 saying that it "Cannot apply PATCH to navigation property users" if we don't null this property out
+                this.Workspace.Users = null;
                 var response = client.Groups.UpdateGroupAsAdmin(this.Workspace.Id.ToString(), this.Workspace);
                 this.Logger.WriteObject(response);
             }

--- a/src/Modules/Workspaces/Commands.Workspaces/WorkspaceType.cs
+++ b/src/Modules/Workspaces/Commands.Workspaces/WorkspaceType.cs
@@ -1,0 +1,16 @@
+﻿/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+namespace Microsoft.PowerBI.Commands.Workspaces
+{
+    public static class WorkspaceType
+    {
+        public static string Personal = "Personal";
+
+        public static string Workspace = "Workspace";
+
+        public static string Group = "Group";
+    }
+}


### PR DESCRIPTION
-End-to-end organization cmdlet tests will avoid using legacy workspaces where not supported
-Removed the warning message from the Get-PowerBIWorkspace cmdlet about preview workspaces
-The Get-PowerBIWorkspace cmdlet supports sending the query options directly to the SDK for the Individual scope
-Refactored tests to improve design and reliability