### PR TITLE
Cc/improv

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+   // Use IntelliSense to find out which attributes exist for C# debugging
+   // Use hover for the description of the existing attributes
+   // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+   "version": "0.2.0",
+   "configurations": [
+        // {
+        //     "name": ".NET Core Launch (console)",
+        //     "type": "coreclr",
+        //     "request": "launch",
+        //     "preLaunchTask": "Build",
+        //     // If you have changed target frameworks, make sure to update the program path.
+        //     "program": "${workspaceFolder}/src/Common/Commands.Common.Test/bin/Debug/netcoreapp2.0/Microsoft.PowerBI.Commands.Common.Test.dll",
+        //     "args": [],
+        //     "cwd": "${workspaceFolder}/src/Common/Commands.Common.Test",
+        //     // For more information about the 'console' field, see https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md#console-terminal-window
+        //     "console": "internalConsole",
+        //     "stopAtEntry": false,
+        //     "internalConsoleOptions": "openOnSessionStart"
+        // },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ,]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "files.exclude": {
+        "**/packages/": true,
+        "**/.vs/": true,
+        "**/bin/": true,
+        "**/obj/": true,
+        "TestResult/": true
+    }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,133 @@
+{
+    // https://code.visualstudio.com/docs/editor/variables-reference
+    "version": "2.0.0",
+    "windows": {
+        "options": {
+            "shell": {
+                "executable": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+                "args": [
+                    "-NoProfile",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-Command"
+                ]
+            }
+        }
+    },
+    "linux": {
+        "options": {
+            "shell": {
+                "executable": "/usr/bin/pwsh",
+                "args": [
+                    "-NoProfile",
+                    "-Command"
+                ]
+            }
+        }
+    },
+    "osx": {
+        "options": {
+            "shell": {
+                "executable": "/usr/local/bin/pwsh",
+                "args": [
+                    "-NoProfile",
+                    "-Command"
+                ]
+            }
+        }
+    },
+    "tasks": [
+        {
+            "label": "Build",
+            "type": "shell",
+            "command": "& '${workspaceFolder}\\scripts\\Build.ps1'",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": "$msCompile"
+        },
+        // {
+        //     "label": "Build",
+        //     "command": "msbuild",
+        //     "args": [
+        //         "/property:GenerateFullPaths=true",
+        //         "/t:build"
+        //     ],
+        //     "group": {
+        //                 "kind": "build",
+        //                 "isDefault": true
+        //             }
+        // },
+        {
+            "label": "Clean",
+            "type": "shell",
+            "command": "& '${workspaceFolder}\\scripts\\Build.ps1' -Clean -NoBuild",
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Pack",
+            "type": "shell",
+            "command": "& '${workspaceFolder}\\scripts\\Build.ps1' -Pack -Clean",
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Restore",
+            "type": "shell",
+            "command": "& '${workspaceFolder}\\scripts\\RestorePackages.ps1'",
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Test",
+            "type": "shell",
+            "command": "& '${workspaceFolder}\\scripts\\Test.ps1'",
+            "group": "test",
+            "problemMatcher": "$msCompile",
+            "presentation": {
+                "reveal": "always",
+                "panel": "new",
+            }
+        },
+        {
+            "label": "PrepManualTesting",
+            "type": "shell",
+            "command": "& '${workspaceFolder}\\scripts\\PrepManualTesting.ps1' -Build -Force",
+            "problemMatcher": "$msCompile",
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": true,
+                "panel": "new",
+                "showReuseMessage": false
+            }
+        },
+        {
+            "label": "DebugTest",
+            "type": "shell",
+            "command": "& '${workspaceFolder}\\scripts\\DebugTest.ps1' -TestName '${selectedText}' -DirectoryName '${fileDirname}'",
+            "problemMatcher": "$msCompile",
+            "isBackground": true,
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": true,
+                "panel": "new",
+                "showReuseMessage": false
+            }
+        },
+        {
+            "label": "DebugTest (No Build)",
+            "type": "shell",
+            "command": "& '${workspaceFolder}\\scripts\\DebugTest.ps1' -TestName '${selectedText}' -DirectoryName '${fileDirname}' -NoBuild",
+            "problemMatcher": "$msCompile",
+            "isBackground": true,
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": true,
+                "panel": "new",
+                "showReuseMessage": false
+            }
+        }
+    ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@
 
 
 > If you plan to build with Configuration=Release which Delay Signs the build output, call `.\scripts\DisableStrongName.ps1`.
-> Add the -Enable to re-enable strong name verification once developing.
+> Add the -Enable switch parameter to re-enable strong name verification once developing.
 
 ### Optional requirements (for testing)
 * [PowerShell Core (6.0.0)](https://github.com/powershell/powershell)
@@ -59,7 +59,7 @@ Optionally you can install the [EditorConfig](https://marketplace.visualstudio.c
 <table>
 
 > * Test Projects are located next to implementation (module project).
-> * AzureADWindowsAuthenticator has an independent dependency stack as it's compiled against .NET 4.6 (opposed to .NET Core) to be a bridge for ADAL on Windows (providing interactive login).
+> * AzureADWindowsAuthenticator has an independent dependency stack as it's compiled against .NET 4.6 (as opposed to .NET Core) to act as a bridge for ADAL on Windows (providing interactive login).
 
 
 
@@ -122,9 +122,10 @@ To run tests, highlight the name of the test with your cursor and press `Ctrl+P`
 3. Implement class and optionally add other interfaces from `Microsoft.PowerBI.Common.Abstractions` for common parameters.
 4. Add `[Cmdlet(CmdletVerb, CmdletName)]` attribute to class and provide `public const string` for `CmdletVerb` and `CmdletName`.
     * For `CmdletVerb`, pick from the System.Management.Automation.Verbs* classes.
-5. Optionally add `[OutputType(typeof(type))]` if your Cmdlet class if it writes an object to the output stream.
-6. Optionally add `[Alias("Get-Alias1", "Get-Alias2")]` to your Cmdlet class. 
-7. Add a test class to verify your cmdlet by adding (replacing with your new class name):
+5. Optionally add `[OutputType(typeof(type))]` if your Cmdlet class writes an object to the output stream.
+6. Optionally add `[Alias("Get-Alias1", "Get-Alias2")]` to your Cmdlet class.
+7. Update PowerShell manifest file (*.ps1), add the new cmdlet to `CmdletsToExport` and if you added an alias update `AliasesToExport` too.
+8. Add a test class to verify your cmdlet by adding (replacing with your new class name):
 ```csharp
 using (var ps = System.Management.Automation.PowerShell.Create())
 {
@@ -135,9 +136,9 @@ using (var ps = System.Management.Automation.PowerShell.Create())
     TestUtilities.AssertNoCmdletErrors(ps);
 }
 ```
-8. If your test is interactive, add method attributes `[TestCategory("Interactive")]` and `[TestCategory("SkipWhenLiveUnitTesting")]` (last tells Live Unit Testing to skip it).
-9. Run test to verify cmdlet is being called correctly.
-10. Add parameters to cmdlet class and implement cmdlet logic in `ExecuteCmdlet()` method.
+9. If your test is interactive, add method attributes `[TestCategory("Interactive")]` and `[TestCategory("SkipWhenLiveUnitTesting")]` (last tells Live Unit Testing to skip it).
+10. Run test to verify cmdlet is being called correctly.
+11. Add parameters to cmdlet class and implement cmdlet logic in `ExecuteCmdlet()` method.
 
 ### Creating a new PowerShell module
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,13 @@ Below is a table of the various Power BI PowerShell modules found in this reposi
 
 | Description | Module Name | PowerShell Gallery link |
 | ----------- | ----------- | ----------------------- |
-| Rollup Module for PowerBI Cmdlets | `MicrosoftPowerBIMgmt` | [![MicrosoftPowerBIMgmt](https://img.shields.io/powershellgallery/v/MicrosoftPowerBIMgmt.svg?style=flat-square&label=MicrosoftPowerBIMgmt)](https://www.powershellgallery.com/packages/MicrosoftPowerBIMgmt/) |
-| Profile module for PowerBI Cmdlets | `MicrosoftPowerBIMgmt.Profile` | [![MicrosoftPowerBIMgmt.Profile](https://img.shields.io/powershellgallery/v/MicrosoftPowerBIMgmt.Profile.svg?style=flat-square&label=MicrosoftPowerBIMgmt.Profile)](https://www.powershellgallery.com/packages/MicrosoftPowerBIMgmt.Profile/) |
-| Workspaces module for PowerBI | `MicrosoftPowerBIMgmt.Workspaces` | [![MicrosoftPowerBIMgmt.Workspaces](https://img.shields.io/powershellgallery/v/MicrosoftPowerBIMgmt.Workspaces.svg?style=flat-square&label=MicrosoftPowerBIMgmt.Workspaces)](https://www.powershellgallery.com/packages/MicrosoftPowerBIMgmt.Workspaces/) |
-| Reports module for PowerBI | `MicrosoftPowerBIMgmt.Reports` | [![MicrosoftPowerBIMgmt.Reports](https://img.shields.io/powershellgallery/v/MicrosoftPowerBIMgmt.Reports.svg?style=flat-square&label=MicrosoftPowerBIMgmt.Reports)](https://www.powershellgallery.com/packages/MicrosoftPowerBIMgmt.Reports/) |
+| Rollup Module for Power BI Cmdlets | `MicrosoftPowerBIMgmt` | [![MicrosoftPowerBIMgmt](https://img.shields.io/powershellgallery/v/MicrosoftPowerBIMgmt.svg?style=flat-square&label=MicrosoftPowerBIMgmt)](https://www.powershellgallery.com/packages/MicrosoftPowerBIMgmt/) |
+| Data module for Power BI Cmdlets | [MicrosoftPowerBIMgmt.Data](https://docs.microsoft.com/en-us/powershell/module/microsoftpowerbimgmt.data) | [![MicrosoftPowerBIMgmt.Data](https://img.shields.io/powershellgallery/v/MicrosoftPowerBIMgmt.Data.svg?style=flat-square&label=MicrosoftPowerBIMgmt.Data)](https://www.powershellgallery.com/packages/MicrosoftPowerBIMgmt.Data/) |
+| Profile module for Power BI Cmdlets | [MicrosoftPowerBIMgmt.Profile](https://docs.microsoft.com/en-us/powershell/module/microsoftpowerbimgmt.profile) | [![MicrosoftPowerBIMgmt.Profile](https://img.shields.io/powershellgallery/v/MicrosoftPowerBIMgmt.Profile.svg?style=flat-square&label=MicrosoftPowerBIMgmt.Profile)](https://www.powershellgallery.com/packages/MicrosoftPowerBIMgmt.Profile/) |
+| Reports module for Power BI | [MicrosoftPowerBIMgmt.Reports](https://docs.microsoft.com/en-us/powershell/module/microsoftpowerbimgmt.reports) | [![MicrosoftPowerBIMgmt.Reports](https://img.shields.io/powershellgallery/v/MicrosoftPowerBIMgmt.Reports.svg?style=flat-square&label=MicrosoftPowerBIMgmt.Reports)](https://www.powershellgallery.com/packages/MicrosoftPowerBIMgmt.Reports/) |
+| Workspaces module for Power BI | [MicrosoftPowerBIMgmt.Workspaces](https://docs.microsoft.com/en-us/powershell/module/microsoftpowerbimgmt.workspaces) | [![MicrosoftPowerBIMgmt.Workspaces](https://img.shields.io/powershellgallery/v/MicrosoftPowerBIMgmt.Workspaces.svg?style=flat-square&label=MicrosoftPowerBIMgmt.Workspaces)](https://www.powershellgallery.com/packages/MicrosoftPowerBIMgmt.Workspaces/) |
+
+More documentation can be found at https://docs.microsoft.com/en-us/powershell/power-bi/overview.
 
 ## Supported Environments and PowerShell Versions
 

--- a/scripts/Build.ps1
+++ b/scripts/Build.ps1
@@ -14,7 +14,7 @@
 # Executes build, pack and clean for the solution.
 #
 #.NOTES
-# Requires Visual Studio 2015 to be installed (at least 15.2 where vswhere.exe is available).
+# Requires Visual Studio 2017 to be installed (at least 15.2 where vswhere.exe is available).
 ##############################
 [CmdletBinding()]
 param

--- a/scripts/Build.ps1
+++ b/scripts/Build.ps1
@@ -27,9 +27,9 @@ param
     [ValidateNotNull()]
     [string[]] $MSBuildTargets = @(),
 
-    # MSBuild properties to execute build with.
+    # MSBuild properties to execute build with. Default is @{'GenerateFullPaths'='true'}.
     [ValidateNotNull()]
-    [Hashtable] $MSBuildProperties = @{},
+    [Hashtable] $MSBuildProperties = @{'GenerateFullPaths'='true'},
 
     # Build Configuration. Default is to use the MSBuild project defaults which is likely Debug.
     [ValidateSet($null, 'Debug', 'Release')]

--- a/scripts/DebugTest.ps1
+++ b/scripts/DebugTest.ps1
@@ -1,7 +1,28 @@
+##############################
+#.SYNOPSIS
+# Executes .\Build.ps1 and .\Test.ps1 for use in debugging unit tests in Visual Studio Code.
+#
+#.DESCRIPTION
+# Invokes MSBuild and dotnet test.
+# Instructs 'dotnet test' to execute a specific test name under a test project (via filter) and allows a debugger to attach to dotnet.exe.
+# Meant to be called from Visual Studio Code, see ..\.vscode\tasks.json.
+#
+#.EXAMPLE
+# PS:> .\DebugTest.ps1 -TestName 'UnitTestName' -DirectoryName 'c:\pbi-ps\src\Modules\Profile\Commands.Profile.Test'
+# Executes a build followed by 'dotnet test' supplying testname and *.csproj located under the directory name to '--filter'.
+#
+#.NOTES
+# Requires Visual Studio 2017 to be installed (at least 15.2 where vswhere.exe is available).
+##############################
 param
 (
+    # Name of unit test to execute.
     [string] $TestName,
+
+    # Directory containing *.csproj for unit test.
     [string] $DirectoryName,
+
+    # Indicates to not build before executing unit tests.
     [switch] $NoBuild
 )
 
@@ -29,13 +50,6 @@ $csProj = Get-ChildItem -Path $DirectoryName -Filter '*.csproj' | Select-Object 
 if(!$csProj) {
     throw "Failed to find CSProj in: $DirectoryName"
 }
-
-# [xml] $csProjXml = Get-Content -Path $csProj.FullName -Raw
-# $pG = $csProjXml.Project.PropertyGroup | Select-Object -First 1
-# $assemblyName = $pG.AssemblyName
-# if(!$assemblyName) {
-#     throw "Failed to get assembly name from CSProj: $($csProj.FullName)"
-# }
 
 # Run tests
 Write-Host "Set breakpoint in test method '$TestName', and use .NET Core Attach to debug test (using process ID)" -ForegroundColor Magenta

--- a/scripts/DebugTest.ps1
+++ b/scripts/DebugTest.ps1
@@ -1,0 +1,42 @@
+param
+(
+    [string] $TestName,
+    [string] $DirectoryName,
+    [switch] $NoBuild
+)
+
+# https://code.visualstudio.com/docs/editor/debugging
+# https://code.visualstudio.com/docs/editor/variables-reference
+
+if(!$TestName) {
+    throw "Select test name in VSCode before running!"
+}
+
+if(!$DirectoryName) {
+    throw "Failed to get directory name"
+}
+
+Write-Host "TestName: $TestName"
+Write-Host "DirectoryName: $DirectoryName"
+
+# Build
+if(!$NoBuild) {
+    & "$PSScriptRoot\Build.ps1"
+}
+
+# Locate test assembly
+$csProj = Get-ChildItem -Path $DirectoryName -Filter '*.csproj' | Select-Object -First 1
+if(!$csProj) {
+    throw "Failed to find CSProj in: $DirectoryName"
+}
+
+# [xml] $csProjXml = Get-Content -Path $csProj.FullName -Raw
+# $pG = $csProjXml.Project.PropertyGroup | Select-Object -First 1
+# $assemblyName = $pG.AssemblyName
+# if(!$assemblyName) {
+#     throw "Failed to get assembly name from CSProj: $($csProj.FullName)"
+# }
+
+# Run tests
+Write-Host "Set breakpoint in test method '$TestName', and use .NET Core Attach to debug test (using process ID)" -ForegroundColor Magenta
+& "$PSScriptRoot\Test.ps1" -VSTestHostDebug -TestName $TestName -TestProject $csProj.BaseName -Filter '' # Set filter to empty string to allow interactive tests to be debugged

--- a/scripts/Test.ps1
+++ b/scripts/Test.ps1
@@ -65,6 +65,7 @@ if(!$testProjects) {
 }
 
 if($VSTestHostDebug) {
+    # Setting this environment variable is necessary for debugging unit tests in Visual Studio Code by instructing 'dotnet test' to wait for a debugger is attached before proceeding.
     # https://github.com/Microsoft/vstest-docs/blob/master/docs/diagnose.md#debug-test-platform-components
     # https://stackoverflow.com/questions/43210794/debugging-mstest-unittests-in-visualstudio-code
     $env:VSTEST_HOST_DEBUG = 1

--- a/scripts/Test.ps1
+++ b/scripts/Test.ps1
@@ -40,6 +40,15 @@ param
     [ValidateSet('', 'quiet', 'minimal', 'normal', 'detailed', 'diagnostic')]
     [string] $Verbosity,
 
+    # Name of test to execute.
+    [string] $TestName,
+
+    # Name of test project to execute.
+    [string] $TestProject,
+
+    # Indicates to launch testing to allow attachment of a debugger.
+    [switch] $VSTestHostDebug,
+
     # Indicates to upload test results to AppVeyor.
     [switch] $UploadResultsToAppVeyor
 )
@@ -55,7 +64,24 @@ if(!$testProjects) {
     throw "Failed to find any test projects under: $Path"
 }
 
+if($VSTestHostDebug) {
+    # https://github.com/Microsoft/vstest-docs/blob/master/docs/diagnose.md#debug-test-platform-components
+    # https://stackoverflow.com/questions/43210794/debugging-mstest-unittests-in-visualstudio-code
+    $env:VSTEST_HOST_DEBUG = 1
+}
+
 $commonDotnetArgs = @('--configuration', $Configuration, '--no-build', '--no-restore')
+if($TestName) {
+    # https://docs.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests
+    $TestName = "Name~$TestName"
+    if($Filter) {
+        $Filter = $Filter + "&$TestName"
+    }
+    else {
+        $Filter = $TestName
+    }
+}
+
 if($Filter) {
     $commonDotnetArgs += @('--filter', "`"$Filter`"")
 }
@@ -71,6 +97,10 @@ if($Verbosity) {
 }
 
 $testProjects | ForEach-Object {
+    if($TestProject -and $_.BaseName -ne $TestProject) {
+        return
+    }
+
     $dotnetArgs = @('test', "`"$($_.FullName)`"")
     $dotnetArgs += $commonDotnetArgs
 

--- a/src/Modules/Profile/Commands.Profile.Test/InvokePowerBIRestMethodTests.cs
+++ b/src/Modules/Profile/Commands.Profile.Test/InvokePowerBIRestMethodTests.cs
@@ -44,14 +44,12 @@ namespace Microsoft.PowerBI.Commands.Profile.Test
             var initFactory = new TestPowerBICmdletNoClientInitFactory(true);
             var testAuthenticator = initFactory.Authenticator; //new TestAuthenticator();
             var accessToken = testAuthenticator.Authenticate(profile: null, logger: null, settings: null, queryParameters: null);
-            var testContentType = "application/test";
             var testHeaderName = "TestExample";
             var testHeaderValue = "Example";
             using (var client = new HttpClient())
             {
                 var mock = new MockInvokePowerBIRestMethodCmdlet(initFactory)
                 {
-                    ContentType = testContentType,
                     Headers = new System.Collections.Hashtable()
                     {
                         { testHeaderName, testHeaderValue }
@@ -62,8 +60,7 @@ namespace Microsoft.PowerBI.Commands.Profile.Test
                 mock.InvokePopulateClient(accessToken, client);
 
                 // Assert
-                Assert.AreEqual(1, client.DefaultRequestHeaders.Accept.Count);
-                Assert.AreEqual(testContentType, client.DefaultRequestHeaders.Accept.ToString());
+                Assert.AreEqual(0, client.DefaultRequestHeaders.Accept.Count);
                 Assert.IsTrue(client.DefaultRequestHeaders.TryGetValues(testHeaderName, out IEnumerable<string> headerValues));
                 Assert.IsNotNull(headerValues);
                 Assert.AreEqual(1, headerValues.Count());

--- a/src/Modules/Profile/Commands.Profile.Test/InvokePowerBIRestMethodTests.cs
+++ b/src/Modules/Profile/Commands.Profile.Test/InvokePowerBIRestMethodTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PowerBI.Commands.Profile.Test
         {
             // Arrange
             var initFactory = new TestPowerBICmdletNoClientInitFactory(true);
-            var testAuthenticator = initFactory.Authenticator; //new TestAuthenticator();
+            var testAuthenticator = initFactory.Authenticator;
             var accessToken = testAuthenticator.Authenticate(profile: null, logger: null, settings: null, queryParameters: null);
             var testHeaderName = "TestExample";
             var testHeaderValue = "Example";

--- a/src/Modules/Profile/Commands.Profile.Test/InvokePowerBIRestMethodTests.cs
+++ b/src/Modules/Profile/Commands.Profile.Test/InvokePowerBIRestMethodTests.cs
@@ -3,8 +3,12 @@
  * Licensed under the MIT License.
  */
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Management.Automation;
+using System.Net.Http;
 using Microsoft.PowerBI.Commands.Common.Test;
+using Microsoft.PowerBI.Common.Abstractions.Interfaces;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.PowerBI.Commands.Profile.Test
@@ -30,6 +34,52 @@ namespace Microsoft.PowerBI.Commands.Profile.Test
 
                 ps.Invoke();
                 TestUtilities.AssertNoCmdletErrors(ps);
+            }
+        }
+
+        [TestMethod]
+        public void InvokePowerBIRestMethod_ModifyHeaders()
+        {
+            // Arrange
+            var initFactory = new TestPowerBICmdletNoClientInitFactory(true);
+            var testAuthenticator = initFactory.Authenticator; //new TestAuthenticator();
+            var accessToken = testAuthenticator.Authenticate(profile: null, logger: null, settings: null, queryParameters: null);
+            var testContentType = "application/test";
+            var testHeaderName = "TestExample";
+            var testHeaderValue = "Example";
+            using (var client = new HttpClient())
+            {
+                var mock = new MockInvokePowerBIRestMethodCmdlet(initFactory)
+                {
+                    ContentType = testContentType,
+                    Headers = new System.Collections.Hashtable()
+                    {
+                        { testHeaderName, testHeaderValue }
+                    }
+                };
+                
+                // Act
+                mock.InvokePopulateClient(accessToken, client);
+
+                // Assert
+                Assert.AreEqual(1, client.DefaultRequestHeaders.Accept.Count);
+                Assert.AreEqual(testContentType, client.DefaultRequestHeaders.Accept.ToString());
+                Assert.IsTrue(client.DefaultRequestHeaders.TryGetValues(testHeaderName, out IEnumerable<string> headerValues));
+                Assert.IsNotNull(headerValues);
+                Assert.AreEqual(1, headerValues.Count());
+                Assert.AreEqual(testHeaderValue, headerValues.First());
+            }
+        }
+
+        private class MockInvokePowerBIRestMethodCmdlet : InvokePowerBIRestMethod
+        {
+            public MockInvokePowerBIRestMethodCmdlet() : base() { }
+
+            public MockInvokePowerBIRestMethodCmdlet(IPowerBICmdletInitFactory init) : base(init) { }
+
+            public void InvokePopulateClient(IAccessToken token, HttpClient client)
+            {
+                base.PopulateClient(token, client);
             }
         }
     }

--- a/src/Modules/Profile/Commands.Profile/help/Invoke-PowerBIRestMethod.md
+++ b/src/Modules/Profile/Commands.Profile/help/Invoke-PowerBIRestMethod.md
@@ -14,7 +14,8 @@ Executes a REST call to the Power BI service, with the specified URL and body.
 
 ```
 Invoke-PowerBIRestMethod -Url <String> -Method <PowerBIWebRequestMethod> [-Body <String>] [-OutFile <String>]
- [-Organization <String>] [-Version <String>] [<CommonParameters>]
+ [-ContentType <String>] [-Headers <Hashtable>] [-Organization <String>] [-Version <String>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -38,6 +39,36 @@ Body of the request, also known as *content*. This is optional unless the reques
 
 ```yaml
 Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ContentType
+Content type to specify inside the header for the request. Default is 'application/json'.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Headers
+Optional headers to include with the request.
+
+```yaml
+Type: Hashtable
 Parameter Sets: (All)
 Aliases:
 


### PR DESCRIPTION
Cmdlet:
* Added -ContentType and -Headers to Invoke-PowerBIRestMethod

Documentation:
* Updated README to include data module
* Added links to docs.microsoft.com to README
* Fixes to contributing guide for architecture and guidance on extending cmdlets
* Added info for VSCode to contributing guide

Internal:
* Added support for Visual Studio Code as an IDE (still need VS installed or .NET Framework SDK)