### PR TITLE
Fixes and enhancements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@
 
 ### Optional requirements (for testing)
 * [PowerShell Core (6.0.0)](https://github.com/powershell/powershell)
-* Windows PowerShell v3 and up with .NET 4.6.1 or above
+* Windows PowerShell v3 and up with .NET 4.7.1 or above
 
 ## Coding Style
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ More documentation can be found at https://docs.microsoft.com/en-us/powershell/p
 
 ## Supported Environments and PowerShell Versions
 
-* Windows PowerShell v3.0 and up with .NET 4.6.1 or above.
+* Windows PowerShell v3.0 and up with .NET 4.7.1 or above.
 * PowerShell Core (v6) and up on any OS platform supported by PowerShell Core.
 
 ## Installation

--- a/scripts/Build.ps1
+++ b/scripts/Build.ps1
@@ -79,7 +79,7 @@ function Get-VSBuildFolder
         throw "Failed to get result from vswhere.exe"
     }
 
-    $vsInstance = $vsWhereOutput | ConvertFrom-Json | Select-Object -First 1
+    $vsInstance = $vsWhereOutput | Out-String | ConvertFrom-Json | Select-Object -First 1
     Write-Verbose "Using VS instance: $($vsInstance.installationPath)"
     Write-Verbose "VS Version: $($vsInstance.installationVersion)"
 

--- a/src/Common/AzureADWindowsAuthenticator/ParsedArguments.cs
+++ b/src/Common/AzureADWindowsAuthenticator/ParsedArguments.cs
@@ -21,5 +21,11 @@ namespace AzureADWindowsAuthenticator
 
         [Parameter("Query")]
         public string QueryParams { get; set; }
+
+        [Parameter("PW")]
+        public string Password { get; set; }
+
+        [Parameter("User")]
+        public string UserName { get; set; }
     }
 }

--- a/src/Common/Commands.Common.Test/TestAuthenticator.cs
+++ b/src/Common/Commands.Common.Test/TestAuthenticator.cs
@@ -43,6 +43,11 @@ namespace Microsoft.PowerBI.Commands.Common.Test
             return this.Token;
         }
 
+        public IAccessToken Authenticate(IPowerBIEnvironment environment, IPowerBILogger logger, IPowerBISettings settings, string userName, SecureString password)
+        {
+            return this.Token;
+        }
+
         public IAccessToken Authenticate(string userName, SecureString password, IPowerBIEnvironment environment, IPowerBILogger logger, IPowerBISettings settings)
         {
             return this.Token;

--- a/src/Common/Commands.Common/AuthenticationFactorySelector.cs
+++ b/src/Common/Commands.Common/AuthenticationFactorySelector.cs
@@ -70,12 +70,20 @@ namespace Microsoft.PowerBI.Commands.Common
             return UserAuthFactory.Authenticate(environment, logger, settings, queryParameters);
         }
 
+        public IAccessToken Authenticate(IPowerBIEnvironment environment, IPowerBILogger logger, IPowerBISettings settings, string userName, SecureString password)
+        {
+            this.InitializeUserAuthenticationFactory(logger, settings);
+            return UserAuthFactory.Authenticate(environment, logger, settings, userName, password);
+        }
+
         public IAccessToken Authenticate(IPowerBIProfile profile, IPowerBILogger logger, IPowerBISettings settings, IDictionary<string, string> queryParameters = null)
         {
             switch (profile.LoginType)
             {
                 case PowerBIProfileType.User:
                     return this.Authenticate(profile.Environment, logger, settings, queryParameters);
+                case PowerBIProfileType.UserAndPassword:
+                    return this.Authenticate(profile.Environment, logger, settings, profile.UserName, profile.Password);
                 case PowerBIProfileType.ServicePrincipal:
                     return this.Authenticate(profile.UserName, profile.Password, profile.Environment, logger, settings);
                 case PowerBIProfileType.Certificate:

--- a/src/Common/Commands.Common/PowerBISettings.cs
+++ b/src/Common/Commands.Common/PowerBISettings.cs
@@ -119,7 +119,16 @@ namespace Microsoft.PowerBI.Commands.Common
             var fileUri = new UriBuilder(codeBase);
             var directory = Uri.UnescapeDataString(fileUri.Path);
             directory = Path.GetDirectoryName(directory);
-            return directory;
+            if (string.IsNullOrEmpty(fileUri.Host))
+            {
+                return directory;
+            }
+            else
+            {
+                // Running on a fileshare
+                directory = $"\\\\{fileUri.Host}\\" + directory.TrimStart(new[] { '\\' });
+                return directory;
+            }
         }
     }
 }

--- a/src/Common/Commands.Common/PowerBISettings.cs
+++ b/src/Common/Commands.Common/PowerBISettings.cs
@@ -15,6 +15,7 @@ using System.Threading.Tasks;
 using System.Xml;
 using Microsoft.PowerBI.Common.Abstractions;
 using Microsoft.PowerBI.Common.Abstractions.Interfaces;
+using Microsoft.PowerBI.Common.Abstractions.Utilities;
 
 namespace Microsoft.PowerBI.Commands.Common
 {
@@ -28,7 +29,7 @@ namespace Microsoft.PowerBI.Commands.Common
         {
             if(string.IsNullOrEmpty(settingsFilePath))
             {
-                var executingDirectory = this.GetExecutingDirectory();
+                var executingDirectory = DirectoryUtility.GetExecutingDirectory();
                 settingsFilePath = Path.Combine(executingDirectory, FileName);
             }
             
@@ -112,23 +113,5 @@ namespace Microsoft.PowerBI.Commands.Common
         public IDictionary<PowerBIEnvironmentType, IPowerBIEnvironment> Environments { get; }
 
         public IPowerBIConfigurationSettings Settings { get; }
-
-        private string GetExecutingDirectory()
-        {
-            string codeBase = Assembly.GetExecutingAssembly().CodeBase;
-            var fileUri = new UriBuilder(codeBase);
-            var directory = Uri.UnescapeDataString(fileUri.Path);
-            directory = Path.GetDirectoryName(directory);
-            if (string.IsNullOrEmpty(fileUri.Host))
-            {
-                return directory;
-            }
-            else
-            {
-                // Running on a fileshare
-                directory = $"\\\\{fileUri.Host}\\" + directory.TrimStart(new[] { '\\' });
-                return directory;
-            }
-        }
     }
 }

--- a/src/Common/Commands.Common/settings.json
+++ b/src/Common/Commands.Common/settings.json
@@ -43,6 +43,18 @@
       "cloudName": "USGovCloud"
     },
     {
+      "name": "USGovHigh",
+      "clientId": "ea0616ba-638b-4df5-95b9-636659ae5121",
+      "redirect": "urn:ietf:wg:oauth:2.0:oob",
+      "cloudName": "USGovDoDL4Cloud"
+    },
+    {
+      "name": "USGovMil",
+      "clientId": "ea0616ba-638b-4df5-95b9-636659ae5121",
+      "redirect": "urn:ietf:wg:oauth:2.0:oob",
+      "cloudName": "USGovDoDL5Cloud"
+    },
+    {
       "name": "China",
       "clientId": "ea0616ba-638b-4df5-95b9-636659ae5121",
       "redirect": "urn:ietf:wg:oauth:2.0:oob",

--- a/src/Common/Common.Abstractions/Interfaces/IAuthenticationUserFactory.cs
+++ b/src/Common/Common.Abstractions/Interfaces/IAuthenticationUserFactory.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Security;
 using System.Text;
 
 namespace Microsoft.PowerBI.Common.Abstractions.Interfaces
@@ -20,5 +21,7 @@ namespace Microsoft.PowerBI.Common.Abstractions.Interfaces
         /// <param name="queryParameters">Query parameters to include with the request. This is optional.</param>
         /// <returns>An IAccessToken of an authenticated user.</returns>
         IAccessToken Authenticate(IPowerBIEnvironment environment, IPowerBILogger logger, IPowerBISettings settings, IDictionary<string, string> queryParameters = null);
+
+        IAccessToken Authenticate(IPowerBIEnvironment environment, IPowerBILogger logger, IPowerBISettings settings, string userName, SecureString password);
     }
 }

--- a/src/Common/Common.Abstractions/PowerBIEnvironmentType.cs
+++ b/src/Common/Common.Abstractions/PowerBIEnvironmentType.cs
@@ -15,6 +15,8 @@ namespace Microsoft.PowerBI.Common.Abstractions
         Public = 0,
         Germany = 1,
         USGov = 2,
-        China = 3
+        China = 3,
+        USGovHigh = 4,
+        USGovMil = 5
     }
 }

--- a/src/Common/Common.Abstractions/PowerBIProfile.cs
+++ b/src/Common/Common.Abstractions/PowerBIProfile.cs
@@ -25,8 +25,8 @@ namespace Microsoft.PowerBI.Common.Abstractions
         public PowerBIProfile(IPowerBIEnvironment environment, IAccessToken token) =>
             (this.Environment, this.TenantId, this.UserName, this.LoginType) = (environment, token.TenantId, token.UserName, PowerBIProfileType.User);
 
-        public PowerBIProfile(IPowerBIEnvironment environment, string userName, SecureString password, IAccessToken token) => 
-            (this.Environment, this.TenantId, this.UserName, this.Password, this.LoginType) = (environment, token.TenantId, userName, password, PowerBIProfileType.ServicePrincipal);
+        public PowerBIProfile(IPowerBIEnvironment environment, string userName, SecureString password, IAccessToken token, bool servicePrincipal = true) => 
+            (this.Environment, this.TenantId, this.UserName, this.Password, this.LoginType) = (environment, token.TenantId, userName, password, servicePrincipal ? PowerBIProfileType.ServicePrincipal : PowerBIProfileType.UserAndPassword);
 
         public PowerBIProfile(IPowerBIEnvironment environment, string clientId, string thumbprint, IAccessToken token) =>
             (this.Environment, this.TenantId, this.UserName, this.Thumbprint, this.LoginType) = (environment, token.TenantId, clientId, thumbprint, PowerBIProfileType.Certificate);

--- a/src/Common/Common.Abstractions/PowerBIProfileType.cs
+++ b/src/Common/Common.Abstractions/PowerBIProfileType.cs
@@ -12,6 +12,7 @@ namespace Microsoft.PowerBI.Common.Abstractions
     {
         User = 0,
         ServicePrincipal = 1,
-        Certificate = 2
+        Certificate = 2,
+        UserAndPassword = 3
     }
 }

--- a/src/Common/Common.Abstractions/Utilities/DirectoryUtility.cs
+++ b/src/Common/Common.Abstractions/Utilities/DirectoryUtility.cs
@@ -1,0 +1,33 @@
+﻿/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+using System;
+using System.IO;
+using System.Reflection;
+
+namespace Microsoft.PowerBI.Common.Abstractions.Utilities
+{
+    public static class DirectoryUtility
+    {
+        public static string GetExecutingDirectory()
+        {
+            string codeBase = Assembly.GetExecutingAssembly().CodeBase;
+            var fileUri = new UriBuilder(codeBase);
+            var directory = Uri.UnescapeDataString(fileUri.Path);
+            directory = Path.GetDirectoryName(directory);
+            if (string.IsNullOrEmpty(fileUri.Host))
+            {
+                return directory;
+            }
+            else
+            {
+                // Running on a fileshare, host from fileUri will be null when executing on a system drive
+                // Path.GetDirectoryName will remove the hostname for the file share so it needs to be added back
+                directory = $"\\\\{fileUri.Host}\\" + directory.TrimStart(new[] { '\\' });
+                return directory;
+            }
+        }
+    }
+}

--- a/src/Common/Common.Api/Reports/ReportsClient.cs
+++ b/src/Common/Common.Api/Reports/ReportsClient.cs
@@ -106,10 +106,10 @@ namespace Microsoft.PowerBI.Common.Api.Reports
 
         public Guid PostImport(string datasetDisplayName, string filePath, ImportConflictHandlerModeEnum nameConflict)
         {
-            using (var fileStream = new StreamReader(filePath))
+            using (var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read))
             {
                 var response = this.Client.Imports.PostImportWithFile(
-                    fileStream: fileStream.BaseStream,
+                    fileStream: fileStream,
                     datasetDisplayName: datasetDisplayName,
                     nameConflict: nameConflict.ToString()
                 );
@@ -119,11 +119,11 @@ namespace Microsoft.PowerBI.Common.Api.Reports
 
         public Guid PostImportForWorkspace(Guid workspaceId, string datasetDisplayName, string filePath, ImportConflictHandlerModeEnum nameConflict)
         {
-            using (var fileStream = new StreamReader(filePath))
+            using (var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read))
             {
                 var response = this.Client.Imports.PostImportWithFileInGroup(
                     groupId: workspaceId.ToString(),
-                    fileStream: fileStream.BaseStream,
+                    fileStream: fileStream,
                     datasetDisplayName: datasetDisplayName,
                     nameConflict: nameConflict.ToString()
                 );

--- a/src/Common/Common.Authentication/DeviceCodeAuthenticationFactory.cs
+++ b/src/Common/Common.Authentication/DeviceCodeAuthenticationFactory.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Security;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Microsoft.PowerBI.Common.Abstractions.Interfaces;
 
@@ -58,6 +59,12 @@ namespace Microsoft.PowerBI.Common.Authentication
             token = context.AcquireTokenByDeviceCodeAsync(deviceCodeResult).Result;
             authenticatedOnce = true;
             return token.ToIAccessToken();
+        }
+
+        public IAccessToken Authenticate(IPowerBIEnvironment environment, IPowerBILogger logger, IPowerBISettings settings, string userName, SecureString password)
+        {
+            // Not supported in .NET Core or DeviceCodeAuthentication - https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/issues/482
+            throw new NotSupportedException("User and password authentication is not supported in .NET Core or with DeviceCode authentication.");
         }
 
         public void Challenge()

--- a/src/Common/Common.Authentication/WindowsAuthenticationFactory.cs
+++ b/src/Common/Common.Authentication/WindowsAuthenticationFactory.cs
@@ -174,7 +174,16 @@ namespace Microsoft.PowerBI.Common.Authentication
             var fileUri = new UriBuilder(codeBase);
             var directory = Uri.UnescapeDataString(fileUri.Path);
             directory = Path.GetDirectoryName(directory);
-            return directory;
+            if (string.IsNullOrEmpty(fileUri.Host))
+            {
+                return directory;
+            }
+            else
+            {
+                // Running on a fileshare
+                directory = $"\\\\{fileUri.Host}\\" + directory.TrimStart(new[] { '\\' });
+                return directory;
+            }
         }
 
         public void Challenge()

--- a/src/Modules/Profile/Commands.Profile/ConnectPowerBIServiceAccount.cs
+++ b/src/Modules/Profile/Commands.Profile/ConnectPowerBIServiceAccount.cs
@@ -85,7 +85,7 @@ namespace Microsoft.PowerBI.Commands.Profile
                     profile = new PowerBIProfile(environment, token);
                     break;
                 case UserAndCredentialPasswordParameterSet:
-                    this.Authenticator.Authenticate(environment, this.Logger, this.Settings, this.Credential.UserName, this.Credential.Password);
+                    token = this.Authenticator.Authenticate(environment, this.Logger, this.Settings, this.Credential.UserName, this.Credential.Password);
                     profile = new PowerBIProfile(environment, this.Credential.UserName, this.Credential.Password, token, servicePrincipal: false);
                     break;
                 case ServicePrincipalCertificateParameterSet:

--- a/src/Modules/Profile/Commands.Profile/ConnectPowerBIServiceAccount.cs
+++ b/src/Modules/Profile/Commands.Profile/ConnectPowerBIServiceAccount.cs
@@ -26,6 +26,7 @@ namespace Microsoft.PowerBI.Commands.Profile
         public const string UserParameterSet = "User";
         public const string ServicePrincipalParameterSet = "ServicePrincipal";
         public const string ServicePrincipalCertificateParameterSet = "ServicePrincipalCertificate";
+        public const string UserAndCredentialPasswordParameterSet = "UserAndCredential";
         #endregion
 
         #region Parameters
@@ -33,6 +34,7 @@ namespace Microsoft.PowerBI.Commands.Profile
         public PowerBIEnvironmentType Environment { get; set; } = PowerBIEnvironmentType.Public;
 
         [Parameter(ParameterSetName = ServicePrincipalParameterSet, Mandatory = true)]
+        [Parameter(ParameterSetName = UserAndCredentialPasswordParameterSet, Mandatory = true)]
         public PSCredential Credential { get; set; }
 
         [Parameter(ParameterSetName = ServicePrincipalCertificateParameterSet, Mandatory = true)]
@@ -81,6 +83,10 @@ namespace Microsoft.PowerBI.Commands.Profile
                         }
                     );
                     profile = new PowerBIProfile(environment, token);
+                    break;
+                case UserAndCredentialPasswordParameterSet:
+                    this.Authenticator.Authenticate(environment, this.Logger, this.Settings, this.Credential.UserName, this.Credential.Password);
+                    profile = new PowerBIProfile(environment, this.Credential.UserName, this.Credential.Password, token, servicePrincipal: false);
                     break;
                 case ServicePrincipalCertificateParameterSet:
                     token = this.Authenticator.Authenticate(this.ApplicationId, this.CertificateThumbprint, environment, this.Logger, this.Settings);

--- a/src/Modules/Profile/Commands.Profile/help/Connect-PowerBIServiceAccount.md
+++ b/src/Modules/Profile/Commands.Profile/help/Connect-PowerBIServiceAccount.md
@@ -23,6 +23,12 @@ Connect-PowerBIServiceAccount [-Environment <PowerBIEnvironmentType>] -Credentia
  [-ServicePrincipal] [-Tenant <String>] [<CommonParameters>]
 ```
 
+### UserAndCredential
+```
+Connect-PowerBIServiceAccount [-Environment <PowerBIEnvironmentType>] -Credential <PSCredential>
+ [<CommonParameters>]
+```
+
 ### ServicePrincipalCertificate
 ```
 Connect-PowerBIServiceAccount [-Environment <PowerBIEnvironmentType>] -CertificateThumbprint <String>
@@ -103,7 +109,7 @@ PSCredential representing the Azure Active Directory (AAD) application client ID
 
 ```yaml
 Type: PSCredential
-Parameter Sets: ServicePrincipal
+Parameter Sets: ServicePrincipal, UserAndCredential
 Aliases:
 
 Required: True

--- a/src/Modules/Reports/Commands.Reports/help/MicrosoftPowerBIMgmt.Reports.md
+++ b/src/Modules/Reports/Commands.Reports/help/MicrosoftPowerBIMgmt.Reports.md
@@ -26,3 +26,6 @@ Returns a list of Power BI reports.
 ### [Get-PowerBITile](Get-PowerBITile.md)
 Returns a list of Power BI tiles for a dashboard.
 
+### [New-PowerBIReport](New-PowerBIReport.md)
+Creates a Power BI report.
+

--- a/src/Modules/Reports/Commands.Reports/help/New-PowerBIReport.md
+++ b/src/Modules/Reports/Commands.Reports/help/New-PowerBIReport.md
@@ -14,14 +14,14 @@ Creates a Power BI report.
 
 ### WorkspaceId (Default)
 ```
-New-PowerBIReport [-Path] <String> [[-Name] <String>] [[-WorkspaceId] <Guid>]
- [[-ConflictAction] <ImportConflictHandlerModeEnum>] [-Timeout <Int32>] [<CommonParameters>]
+New-PowerBIReport [-Path] <String> [-Name <String>] [-WorkspaceId <Guid>]
+ [-ConflictAction <ImportConflictHandlerModeEnum>] [-Timeout <Int32>] [<CommonParameters>]
 ```
 
 ### Workspace
 ```
-New-PowerBIReport [-Path] <String> [[-Name] <String>] [[-Workspace] <Workspace>]
- [[-ConflictAction] <ImportConflictHandlerModeEnum>] [-Timeout <Int32>] [<CommonParameters>]
+New-PowerBIReport [-Path] <String> [-Name <String>] [-Workspace <Workspace>]
+ [-ConflictAction <ImportConflictHandlerModeEnum>] [-Timeout <Int32>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -53,7 +53,7 @@ Determines what to do if a dataset with the same name already exists. Default va
 Type: ImportConflictHandlerModeEnum
 Parameter Sets: (All)
 Aliases:
-Accepted values: Abort, CreateOrOverwrite, Ignore, Overwrite
+Accepted values: Ignore, Abort, Overwrite, CreateOrOverwrite
 
 Required: False
 Position: Named


### PR DESCRIPTION
- Connect-PowerBIServiceAccount -Credential   (without -ServicePrincipal).
    - Works only on Windows OS (Windows PowerShell or PowerShell Core)
    - Addresses issues  #59, #49, #51 and possibly #85
- Added GCC High and Military to environment list
    - Addresses issue #91 
- Updated doc to state 4.7.1 as minimum .NET version
    - Addresses issues #82 #60 
- Added Out-String to vsWhere call #76 
- Fixed issue where cmdlets couldn't load on a network file share #87 
- Fixes for new cmdlet New-PowerBIReport