### PR TITLE
All parameter cannot be used along with Name, Id, First & Skip.

### DIFF
--- a/src/Common/Common.Api/Workspaces/Workspace.cs
+++ b/src/Common/Common.Api/Workspaces/Workspace.cs
@@ -61,5 +61,15 @@ namespace Microsoft.PowerBI.Common.Api.Workspaces
                 Users = workspace.Users?.Select(x => (GroupUserAccessRight)x).ToList()
             };
         }
+
+        public bool IsOrphanedWorkspace()
+        {
+            if (this.Type.Equals("Group") || this.Type.Equals("PersonalGroup"))
+            {
+                return false;
+            }
+
+            return (this.Users == null) || (!this.Users.Any(u => u.AccessRight.Equals("Admin")));
+        }
     }
 }

--- a/src/Common/Common.Api/Workspaces/Workspace.cs
+++ b/src/Common/Common.Api/Workspaces/Workspace.cs
@@ -32,12 +32,12 @@ namespace Microsoft.PowerBI.Common.Api.Workspaces
         {
             get
             {
-                if (this.State == null || this.State.Equals("Deleted") || this.Type.Equals("Group") || this.Type.Equals("PersonalGroup"))
+                if (this.State == null || this.State.Equals(WorkspaceState.Deleted) || this.Type.Equals(WorkspaceType.Group) || this.Type.Equals(WorkspaceType.PersonalGroup))
                 {
                     return false;
                 }
 
-                return (this.Users == null) || (!this.Users.Any(u => u.AccessRight.Equals("Admin")));
+                return (this.Users == null) || (!this.Users.Any(u => u.AccessRight.Equals(WorkspaceUserAccessRight.Admin.ToString())));
             }
         }
 

--- a/src/Common/Common.Api/Workspaces/Workspace.cs
+++ b/src/Common/Common.Api/Workspaces/Workspace.cs
@@ -28,6 +28,19 @@ namespace Microsoft.PowerBI.Common.Api.Workspaces
 
         public string State { get; set; }
 
+        public bool IsOrphaned
+        {
+            get
+            {
+                if (this.State == null || this.State.Equals("Deleted") || this.Type.Equals("Group") || this.Type.Equals("PersonalGroup"))
+                {
+                    return false;
+                }
+
+                return (this.Users == null) || (!this.Users.Any(u => u.AccessRight.Equals("Admin")));
+            }
+        }
+
         public IEnumerable<WorkspaceUser> Users { get; set; }
 
         public static implicit operator Workspace(Group group)
@@ -60,16 +73,6 @@ namespace Microsoft.PowerBI.Common.Api.Workspaces
                 State = workspace.State,
                 Users = workspace.Users?.Select(x => (GroupUserAccessRight)x).ToList()
             };
-        }
-
-        public bool IsOrphanedWorkspace()
-        {
-            if (this.Type.Equals("Group") || this.Type.Equals("PersonalGroup"))
-            {
-                return false;
-            }
-
-            return (this.Users == null) || (!this.Users.Any(u => u.AccessRight.Equals("Admin")));
         }
     }
 }

--- a/src/Common/Common.Api/Workspaces/WorkspaceState.cs
+++ b/src/Common/Common.Api/Workspaces/WorkspaceState.cs
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-namespace Microsoft.PowerBI.Commands.Workspaces
+namespace Microsoft.PowerBI.Common.Api.Workspaces
 {
     public static class WorkspaceState
     {

--- a/src/Common/Common.Api/Workspaces/WorkspaceType.cs
+++ b/src/Common/Common.Api/Workspaces/WorkspaceType.cs
@@ -3,11 +3,11 @@
  * Licensed under the MIT License.
  */
 
-namespace Microsoft.PowerBI.Commands.Workspaces
+namespace Microsoft.PowerBI.Common.Api.Workspaces
 {
     public static class WorkspaceType
     {
-        public static string Personal = "Personal";
+        public static string PersonalGroup = "PersonalGroup";
 
         public static string Workspace = "Workspace";
 

--- a/src/Common/Common.Api/Workspaces/WorkspaceUserAccessRight.cs
+++ b/src/Common/Common.Api/Workspaces/WorkspaceUserAccessRight.cs
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-namespace Microsoft.PowerBI.Commands.Workspaces
+namespace Microsoft.PowerBI.Common.Api.Workspaces
 {
     public enum WorkspaceUserAccessRight
     {

--- a/src/Common/Common.Client/PowerBIGetCmdlet.cs
+++ b/src/Common/Common.Client/PowerBIGetCmdlet.cs
@@ -12,7 +12,7 @@ namespace Microsoft.PowerBI.Common.Client
 {
     public abstract class PowerBIGetCmdlet : PowerBIClientCmdlet
     {
-        protected const string AllParameterSetName = "WithAll";
+        protected const string AllParameterSetName = "All";
 
         public PowerBIGetCmdlet(): base() { }
 

--- a/src/Modules/Workspaces/Commands.Workspaces.Test/GetPowerBIWorkspaceTests.cs
+++ b/src/Modules/Workspaces/Commands.Workspaces.Test/GetPowerBIWorkspaceTests.cs
@@ -799,7 +799,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         public void GetWorkspacesOrganizationScopeSupportsOrphaned()
         {
             // Arrange
-            var filter = "(not users/any()) or (not users/any(u: u/groupUserAccessRight eq Microsoft.PowerBI.ServiceContracts.Api.GroupUserAccessRight'Admin'))";
+            var filter = string.Format("(state ne '{0}') and ((not users/any()) or (not users/any(u: u/groupUserAccessRight eq Microsoft.PowerBI.ServiceContracts.Api.GroupUserAccessRight'Admin')))", WorkspaceState.Deleted);
             var expectedWorkspaces = new List<Workspace> { new Workspace { Id = Guid.NewGuid(), Name = "TestWorkspace" } };
             var client = new Mock<IPowerBIApiClient>();
             client.Setup(x => x.Workspaces.GetWorkspacesAsAdmin("users", filter, It.IsAny<int>(), null)).Returns(expectedWorkspaces);

--- a/src/Modules/Workspaces/Commands.Workspaces.Test/GetPowerBIWorkspaceTests.cs
+++ b/src/Modules/Workspaces/Commands.Workspaces.Test/GetPowerBIWorkspaceTests.cs
@@ -799,7 +799,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         public void GetWorkspacesOrganizationScopeSupportsOrphaned()
         {
             // Arrange
-            var filter = string.Format("(state ne '{0}') and ((not users/any()) or (not users/any(u: u/groupUserAccessRight eq Microsoft.PowerBI.ServiceContracts.Api.GroupUserAccessRight'Admin')))", WorkspaceState.Deleted);
+            var filter = $"(state ne '{WorkspaceState.Deleted}') and ((not users/any()) or (not users/any(u: u/groupUserAccessRight eq Microsoft.PowerBI.ServiceContracts.Api.GroupUserAccessRight'Admin')))";
             var expectedWorkspaces = new List<Workspace> { new Workspace { Id = Guid.NewGuid(), Name = "TestWorkspace" } };
             var client = new Mock<IPowerBIApiClient>();
             client.Setup(x => x.Workspaces.GetWorkspacesAsAdmin("users", filter, It.IsAny<int>(), null)).Returns(expectedWorkspaces);

--- a/src/Modules/Workspaces/Commands.Workspaces.Test/GetPowerBIWorkspaceTests.cs
+++ b/src/Modules/Workspaces/Commands.Workspaces.Test/GetPowerBIWorkspaceTests.cs
@@ -456,9 +456,9 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         public void GetWorkspacesAllOrphanedWithNullUsers()
         {
             // Arrange
-            var expectedWorkspace = new Workspace { Id = Guid.NewGuid(), Name = "TestOrphanedWorkspace", State = WorkspaceState.Active };
+            var expectedWorkspace = new Workspace { Id = Guid.NewGuid(), Name = "TestOrphanedWorkspace", Type = WorkspaceType.Workspace, State = WorkspaceState.Active };
             var user = new WorkspaceUser { UserPrincipalName = "randomUser@pbi.com", AccessRight = WorkspaceUserAccessRight.Admin.ToString() };
-            var allWorkspaces = new List<Workspace> { new Workspace { Id = Guid.NewGuid(), Name = "TestWorkspace", State = WorkspaceState.Active, Users = new List<WorkspaceUser> { user } }, expectedWorkspace };
+            var allWorkspaces = new List<Workspace> { new Workspace { Id = Guid.NewGuid(), Name = "TestWorkspace", Type = WorkspaceType.Workspace, State = WorkspaceState.Active, Users = new List<WorkspaceUser> { user } }, expectedWorkspace };
 
             var client = new Mock<IPowerBIApiClient>();
             client.Setup(x => x.Workspaces.GetWorkspacesAsAdmin("users", null, It.IsAny<int>(), It.IsAny<int>())).Returns(allWorkspaces);
@@ -481,9 +481,9 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         public void GetWorkspacesAllOrphanedWithEmptyUsers()
         {
             // Arrange
-            var expectedWorkspace = new Workspace { Id = Guid.NewGuid(), Name = "TestOrphanedWorkspace", State = WorkspaceState.Active, Users = new List<WorkspaceUser>() };
+            var expectedWorkspace = new Workspace { Id = Guid.NewGuid(), Name = "TestOrphanedWorkspace", Type = WorkspaceType.Workspace, State = WorkspaceState.Active, Users = new List<WorkspaceUser>() };
             var user = new WorkspaceUser { UserPrincipalName = "randomUser@pbi.com", AccessRight = WorkspaceUserAccessRight.Admin.ToString() };
-            var allWorkspaces = new List<Workspace> { new Workspace { Id = Guid.NewGuid(), Name = "TestWorkspace", State = WorkspaceState.Active, Users = new List<WorkspaceUser> { user } }, expectedWorkspace };
+            var allWorkspaces = new List<Workspace> { new Workspace { Id = Guid.NewGuid(), Name = "TestWorkspace", Type = WorkspaceType.Workspace, State = WorkspaceState.Active, Users = new List<WorkspaceUser> { user } }, expectedWorkspace };
 
             var client = new Mock<IPowerBIApiClient>();
             client.Setup(x => x.Workspaces.GetWorkspacesAsAdmin("users", null, It.IsAny<int>(), It.IsAny<int>())).Returns(allWorkspaces);
@@ -508,10 +508,10 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
             // Arrange
             var user1 = new WorkspaceUser { UserPrincipalName = "randomUser1@pbi.com", AccessRight = WorkspaceUserAccessRight.Member.ToString() };
             var user2 = new WorkspaceUser { UserPrincipalName = "randomUser2@pbi.com", AccessRight = WorkspaceUserAccessRight.Contributor.ToString() };
-            var expectedWorkspace = new Workspace { Id = Guid.NewGuid(), Name = "TestOrphanedWorkspace", State = WorkspaceState.Active, Users = new List<WorkspaceUser> { user1, user2 } };
+            var expectedWorkspace = new Workspace { Id = Guid.NewGuid(), Name = "TestOrphanedWorkspace", Type = WorkspaceType.Workspace, State = WorkspaceState.Active, Users = new List<WorkspaceUser> { user1, user2 } };
 
             var user = new WorkspaceUser { UserPrincipalName = "randomUser@pbi.com", AccessRight = WorkspaceUserAccessRight.Admin.ToString() };
-            var allWorkspaces = new List<Workspace> { new Workspace { Id = Guid.NewGuid(), Name = "TestWorkspace", State = WorkspaceState.Active, Users = new List<WorkspaceUser> { user } }, expectedWorkspace };
+            var allWorkspaces = new List<Workspace> { new Workspace { Id = Guid.NewGuid(), Name = "TestWorkspace", Type = WorkspaceType.Workspace, State = WorkspaceState.Active, Users = new List<WorkspaceUser> { user } }, expectedWorkspace };
 
             var client = new Mock<IPowerBIApiClient>();
             client.Setup(x => x.Workspaces.GetWorkspacesAsAdmin("users", null, It.IsAny<int>(), It.IsAny<int>())).Returns(allWorkspaces);
@@ -531,16 +531,46 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         }
 
         [TestMethod]
-        public void GetWorkspacesAllOrphanedDeletedAndUser()
+        public void GetWorkspacesAllAndUser()
+        {
+            // Arrange
+            var user = new WorkspaceUser { UserPrincipalName = "randomUser@pbi.com", AccessRight = WorkspaceUserAccessRight.Admin.ToString() };
+            var user1 = new WorkspaceUser { UserPrincipalName = "randomUser1@pbi.com", AccessRight = WorkspaceUserAccessRight.Member.ToString() };
+            var user2 = new WorkspaceUser { UserPrincipalName = "randomUser2@pbi.com", AccessRight = WorkspaceUserAccessRight.Contributor.ToString() };
+            var orphanedWorkspace = new Workspace { Id = Guid.NewGuid(), Name = "TestOrphanedWorkspace", Type = WorkspaceType.Workspace, State = WorkspaceState.Active, Users = new List<WorkspaceUser> { user1, user2 } };
+            var deletedWorkspace = new Workspace { Id = Guid.NewGuid(), Name = "TestDeletedWorkspace", Type = WorkspaceType.Workspace, State = WorkspaceState.Deleted };
+            var normalWorkspace = new Workspace { Id = Guid.NewGuid(), Name = "TestWorkspace", Type = WorkspaceType.Workspace, State = WorkspaceState.Active, Users = new List<WorkspaceUser> { user } };
+
+            var allWorkspaces = new List<Workspace> { normalWorkspace, deletedWorkspace, orphanedWorkspace };
+
+            var client = new Mock<IPowerBIApiClient>();
+            client.Setup(x => x.Workspaces.GetWorkspacesAsAdmin("users", null, It.IsAny<int>(), It.IsAny<int>())).Returns(allWorkspaces);
+            var initFactory = new TestPowerBICmdletInitFactory(client.Object);
+            var cmdlet = new GetPowerBIWorkspace(initFactory)
+            {
+                Scope = PowerBIUserScope.Organization,
+                All = true,
+                User = "randomUser@pbi.com",
+            };
+
+            // Act
+            cmdlet.InvokePowerBICmdlet();
+
+            // Assert
+            AssertExpectedUnitTestResults(new List<Workspace> { normalWorkspace }, initFactory);
+        }
+
+        [TestMethod]
+        public void GetWorkspacesAllOrphanedAndUser()
         {
             // Arrange
             var user1 = new WorkspaceUser { UserPrincipalName = "randomUser1@pbi.com", AccessRight = WorkspaceUserAccessRight.Member.ToString() };
             var user2 = new WorkspaceUser { UserPrincipalName = "randomUser2@pbi.com", AccessRight = WorkspaceUserAccessRight.Contributor.ToString() };
-            var expectedOrphanedWorkspace = new Workspace { Id = Guid.NewGuid(), Name = "TestOrphanedWorkspace", State = WorkspaceState.Active, Users = new List<WorkspaceUser> { user1, user2 } };
-            var expectedDeletedWorkspace = new Workspace { Id = Guid.NewGuid(), Name = "TestDeletedWorkspace", State = WorkspaceState.Deleted, Users = new List<WorkspaceUser> { user1 } };
+            var expectedOrphanedWorkspace = new Workspace { Id = Guid.NewGuid(), Name = "TestOrphanedWorkspace", Type = WorkspaceType.Workspace, State = WorkspaceState.Active, Users = new List<WorkspaceUser> { user1, user2 } };
+            var expectedDeletedWorkspace = new Workspace { Id = Guid.NewGuid(), Name = "TestDeletedWorkspace", Type = WorkspaceType.Workspace, State = WorkspaceState.Deleted };
 
             var user = new WorkspaceUser { UserPrincipalName = "randomUser@pbi.com", AccessRight = WorkspaceUserAccessRight.Admin.ToString() };
-            var allWorkspaces = new List<Workspace> { new Workspace { Id = Guid.NewGuid(), Name = "TestWorkspace", State = WorkspaceState.Active, Users = new List<WorkspaceUser> { user } }, expectedDeletedWorkspace, expectedOrphanedWorkspace };
+            var allWorkspaces = new List<Workspace> { new Workspace { Id = Guid.NewGuid(), Name = "TestWorkspace", Type = WorkspaceType.Workspace, State = WorkspaceState.Active, Users = new List<WorkspaceUser> { user } }, expectedDeletedWorkspace, expectedOrphanedWorkspace };
 
             var client = new Mock<IPowerBIApiClient>();
             client.Setup(x => x.Workspaces.GetWorkspacesAsAdmin("users", null, It.IsAny<int>(), It.IsAny<int>())).Returns(allWorkspaces);
@@ -550,6 +580,36 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
                 Scope = PowerBIUserScope.Organization,
                 All = true,
                 User = "randomUser1@pbi.com",
+                Orphaned = true
+            };
+
+            // Act
+            cmdlet.InvokePowerBICmdlet();
+
+            // Assert
+            AssertExpectedUnitTestResults(new List<Workspace> { expectedOrphanedWorkspace }, initFactory);
+        }
+
+        [TestMethod]
+        public void GetWorkspacesAllDeletedAndOrphaned()
+        {
+            // Arrange
+            var user1 = new WorkspaceUser { UserPrincipalName = "randomUser1@pbi.com", AccessRight = WorkspaceUserAccessRight.Member.ToString() };
+            var user2 = new WorkspaceUser { UserPrincipalName = "randomUser2@pbi.com", AccessRight = WorkspaceUserAccessRight.Contributor.ToString() };
+            var deletedWorkspaceOne = new Workspace { Id = Guid.NewGuid(), Name = "TestDeletedWorkspace1", Type = WorkspaceType.Workspace, State = WorkspaceState.Deleted };
+            var deletedWorkspaceTwo = new Workspace { Id = Guid.NewGuid(), Name = "TestDeletedWorkspace2", Type = WorkspaceType.Group, State = WorkspaceState.Deleted };
+            var orphanedWorkspace = new Workspace { Id = Guid.NewGuid(), Name = "TestOrphanedWorkspace", Type = WorkspaceType.Workspace, State = WorkspaceState.Active, Users = new List<WorkspaceUser> { user1, user2 } };
+
+            var user = new WorkspaceUser { UserPrincipalName = "randomUser@pbi.com", AccessRight = WorkspaceUserAccessRight.Admin.ToString() };
+            var allWorkspaces = new List<Workspace> { new Workspace { Id = Guid.NewGuid(), Name = "TestWorkspace", Type = WorkspaceType.Workspace, State = WorkspaceState.Active, Users = new List<WorkspaceUser> { user } }, deletedWorkspaceOne, deletedWorkspaceTwo, orphanedWorkspace };
+
+            var client = new Mock<IPowerBIApiClient>();
+            client.Setup(x => x.Workspaces.GetWorkspacesAsAdmin("users", null, It.IsAny<int>(), It.IsAny<int>())).Returns(allWorkspaces);
+            var initFactory = new TestPowerBICmdletInitFactory(client.Object);
+            var cmdlet = new GetPowerBIWorkspace(initFactory)
+            {
+                Scope = PowerBIUserScope.Organization,
+                All = true,
                 Orphaned = true,
                 Deleted = true
             };
@@ -558,7 +618,36 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
             cmdlet.InvokePowerBICmdlet();
 
             // Assert
-            AssertExpectedUnitTestResults(new List<Workspace> { expectedDeletedWorkspace, expectedOrphanedWorkspace }, initFactory);
+            AssertExpectedUnitTestResults(new List<Workspace> { deletedWorkspaceOne }, initFactory);
+        }
+
+        [TestMethod]
+        public void GetWorkspacesAllOrphanedWithGroup()
+        {
+            // Arrange
+            var user1 = new WorkspaceUser { UserPrincipalName = "randomUser1@pbi.com", AccessRight = WorkspaceUserAccessRight.Member.ToString() };
+            var user2 = new WorkspaceUser { UserPrincipalName = "randomUser2@pbi.com", AccessRight = WorkspaceUserAccessRight.Contributor.ToString() };
+            var expectedOrphanedWorkspaceOne = new Workspace { Id = Guid.NewGuid(), Name = "TestOrphanedWorkspace", Type = WorkspaceType.Workspace, State = WorkspaceState.Active, Users = new List<WorkspaceUser> { user1, user2 } };
+            var expectedOrphanedWorkspaceTwo = new Workspace { Id = Guid.NewGuid(), Name = "TestDeletedWorkspace", Type = WorkspaceType.Group, State = WorkspaceState.Active, Users = new List<WorkspaceUser> { user1 } };
+
+            var user = new WorkspaceUser { UserPrincipalName = "randomUser@pbi.com", AccessRight = WorkspaceUserAccessRight.Admin.ToString() };
+            var allWorkspaces = new List<Workspace> { new Workspace { Id = Guid.NewGuid(), Name = "TestWorkspace", Type = WorkspaceType.Workspace, State = WorkspaceState.Active, Users = new List<WorkspaceUser> { user } }, expectedOrphanedWorkspaceOne, expectedOrphanedWorkspaceTwo };
+
+            var client = new Mock<IPowerBIApiClient>();
+            client.Setup(x => x.Workspaces.GetWorkspacesAsAdmin("users", null, It.IsAny<int>(), It.IsAny<int>())).Returns(allWorkspaces);
+            var initFactory = new TestPowerBICmdletInitFactory(client.Object);
+            var cmdlet = new GetPowerBIWorkspace(initFactory)
+            {
+                Scope = PowerBIUserScope.Organization,
+                All = true,
+                Orphaned = true
+            };
+
+            // Act
+            cmdlet.InvokePowerBICmdlet();
+
+            // Assert
+            AssertExpectedUnitTestResults(new List<Workspace> { expectedOrphanedWorkspaceOne }, initFactory);
         }
 
         [TestMethod]

--- a/src/Modules/Workspaces/Commands.Workspaces/GetPowerBIWorkspace.cs
+++ b/src/Modules/Workspaces/Commands.Workspaces/GetPowerBIWorkspace.cs
@@ -63,9 +63,6 @@ namespace Microsoft.PowerBI.Commands.Workspaces
         [Parameter(Mandatory = false, ParameterSetName = AllParameterSetName)]
         public SwitchParameter Orphaned { get; set; }
 
-        [Parameter(Mandatory = true, ParameterSetName = AllParameterSetName)]
-        public override SwitchParameter All { get; set; }
-
         [Parameter(Mandatory = false, ParameterSetName = ListParameterSetName)]
         [Alias("Top")]
         public int? First { get; set; }
@@ -166,7 +163,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces
 
                 if (defaultingFirst && workspaces.Count() == 100)
                 {
-                    this.Logger.WriteWarning("Defaulting to return only the top 100 workspaces. Use -First & -Skip (or) -All to view more.");
+                    this.Logger.WriteWarning("Defaulted to show top 100 workspaces. Use -First & -Skip or -All to retrieve more results.");
                 }
 
                 this.Logger.WriteObject(workspaces, true);

--- a/src/Modules/Workspaces/Commands.Workspaces/GetPowerBIWorkspace.cs
+++ b/src/Modules/Workspaces/Commands.Workspaces/GetPowerBIWorkspace.cs
@@ -27,9 +27,9 @@ namespace Microsoft.PowerBI.Commands.Workspaces
         private const string ListParameterSetName = "List";
 
         // Since internally, users are null rather than an empty list on workspaces v1 (groups), we don't need to filter on type for the time being
-        private string OrphanedFilterString = string.Format("(state ne '{0}') and ((not users/any()) or (not users/any(u: u/groupUserAccessRight eq Microsoft.PowerBI.ServiceContracts.Api.GroupUserAccessRight'Admin')))", WorkspaceState.Deleted);
+        private string OrphanedFilterString = $"(state ne '{WorkspaceState.Deleted}') and ((not users/any()) or (not users/any(u: u/groupUserAccessRight eq Microsoft.PowerBI.ServiceContracts.Api.GroupUserAccessRight'Admin')))";
 
-        private string DeletedFilterString = string.Format("state eq '{0}'", WorkspaceState.Deleted);
+        private string DeletedFilterString = $"state eq '{WorkspaceState.Deleted}'";
 
         public GetPowerBIWorkspace() : base() { }
 

--- a/src/Modules/Workspaces/Commands.Workspaces/Microsoft.PowerBI.Commands.Workspaces.format.ps1xml
+++ b/src/Modules/Workspaces/Commands.Workspaces/Microsoft.PowerBI.Commands.Workspaces.format.ps1xml
@@ -44,6 +44,10 @@
                 <ScriptBlock>$_.IsReadOnly</ScriptBlock>
               </ListItem>
               <ListItem>
+                <Label>IsOrphaned</Label>
+                <ScriptBlock>$_.IsOrphaned</ScriptBlock>
+              </ListItem>
+              <ListItem>
                 <Label>IsOnDedicatedCapacity</Label>
                 <ScriptBlock>$_.IsOnDedicatedCapacity</ScriptBlock>
               </ListItem>

--- a/src/Modules/Workspaces/Commands.Workspaces/help/Get-PowerBIWorkspace.md
+++ b/src/Modules/Workspaces/Commands.Workspaces/help/Get-PowerBIWorkspace.md
@@ -20,18 +20,18 @@ Get-PowerBIWorkspace [-Scope <PowerBIUserScope>] [-Filter <String>] [-User <Stri
 
 ### Id
 ```
-Get-PowerBIWorkspace -Id <Guid> [-Scope <PowerBIUserScope>] [-All] [<CommonParameters>]
+Get-PowerBIWorkspace -Id <Guid> [-Scope <PowerBIUserScope>] [<CommonParameters>]
 ```
 
 ### Name
 ```
-Get-PowerBIWorkspace -Name <String> [-Scope <PowerBIUserScope>] [-All] [<CommonParameters>]
+Get-PowerBIWorkspace -Name <String> [-Scope <PowerBIUserScope>] [<CommonParameters>]
 ```
 
-### WithAll
+### All
 ```
-Get-PowerBIWorkspace [-Scope <PowerBIUserScope>] [-Filter <String>] [-User <String>] [-Deleted] [-Orphaned]
- [-All] [<CommonParameters>]
+Get-PowerBIWorkspace [-Scope <PowerBIUserScope>] [-User <String>] [-Deleted] [-Orphaned] [-All]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -57,23 +57,11 @@ Returns a workspace named 'Contoso Sales' (case insensitive with tolower) within
 ## PARAMETERS
 
 ### -All
-Indicates to show all the workspaces. Only supported when -Scope Organization is specified. -First and -Skip cannot be used with this parameter.
+Indicates to show all the workspaces. Only supported when -Scope Organization is specified. -First, -Skip and -Filter cannot be used with this parameter.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: Id, Name
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: WithAll
+Parameter Sets: All
 Aliases:
 
 Required: True
@@ -88,7 +76,7 @@ Indicates to show only deleted workspaces. Only supported when -Scope Organizati
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: List, WithAll
+Parameter Sets: List, All
 Aliases:
 
 Required: False
@@ -103,7 +91,7 @@ OData filter, case-sensitive (element names start lowercase).
 
 ```yaml
 Type: String
-Parameter Sets: List, WithAll
+Parameter Sets: List
 Aliases:
 
 Required: False
@@ -163,7 +151,7 @@ Indicates to show only orphaned workspaces. Only supported when -Scope Organizat
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: List, WithAll
+Parameter Sets: List, All
 Aliases:
 
 Required: False
@@ -209,7 +197,7 @@ Filter workspaces to show ones which the user is contained within. Only availabl
 
 ```yaml
 Type: String
-Parameter Sets: List, WithAll
+Parameter Sets: List, All
 Aliases:
 
 Required: False

--- a/src/Modules/Workspaces/Commands.Workspaces/help/Get-PowerBIWorkspace.md
+++ b/src/Modules/Workspaces/Commands.Workspaces/help/Get-PowerBIWorkspace.md
@@ -30,8 +30,8 @@ Get-PowerBIWorkspace -Name <String> [-Scope <PowerBIUserScope>] [<CommonParamete
 
 ### All
 ```
-Get-PowerBIWorkspace [-Scope <PowerBIUserScope>] [-User <String>] [-Deleted] [-Orphaned] [-All]
- [<CommonParameters>]
+Get-PowerBIWorkspace [-Scope <PowerBIUserScope>] [-Filter <String>] [-User <String>] [-Deleted] [-Orphaned]
+ [-All] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -57,7 +57,7 @@ Returns a workspace named 'Contoso Sales' (case insensitive with tolower) within
 ## PARAMETERS
 
 ### -All
-Indicates to show all the workspaces. Only supported when -Scope Organization is specified. -First, -Skip and -Filter cannot be used with this parameter.
+Indicates to show all the workspaces. Only supported when -Scope Organization is specified. -First and -Skip cannot be used with this parameter.
 
 ```yaml
 Type: SwitchParameter
@@ -91,7 +91,7 @@ OData filter, case-sensitive (element names start lowercase).
 
 ```yaml
 Type: String
-Parameter Sets: List
+Parameter Sets: List, All
 Aliases:
 
 Required: False

--- a/src/Modules/Workspaces/Commands.Workspaces/help/Get-PowerBIWorkspace.md
+++ b/src/Modules/Workspaces/Commands.Workspaces/help/Get-PowerBIWorkspace.md
@@ -102,7 +102,7 @@ Accept wildcard characters: False
 ```
 
 ### -First
-First (top) list of results. This value defaults to 5000.
+First (top) list of results. This value defaults to 100.
 
 ```yaml
 Type: Int32


### PR DESCRIPTION
Performing filtering on client side whenever -All is provided.