### PR TITLE
Fix deserialization issue with the GetTenantPolicy call in the client

### DIFF
--- a/src/Common/Common.Api.Test/GatewayClientTests.cs
+++ b/src/Common/Common.Api.Test/GatewayClientTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.PowerBI.Common.Api.Test
                 GatewayUpgradeState = "the upgrade state"
             };
 
-            var serializedODataRepsonse = JsonConvert.SerializeObject(oDataResponse);
+            var serializedODataRepsonse = JsonConvert.SerializeObject(oDataResponse, new Newtonsoft.Json.Converters.StringEnumConverter());
             var client = Utilities.GetTestClient(serializedODataRepsonse);
 
             // Act
@@ -189,7 +189,7 @@ namespace Microsoft.PowerBI.Common.Api.Test
                 }
             };
 
-            var serializedODataRepsonse = JsonConvert.SerializeObject(oDataResponse);
+            var serializedODataRepsonse = JsonConvert.SerializeObject(oDataResponse, new Newtonsoft.Json.Converters.StringEnumConverter());
             var client = Utilities.GetTestClient(serializedODataRepsonse);
 
             // Act
@@ -289,7 +289,7 @@ namespace Microsoft.PowerBI.Common.Api.Test
                 }
             };
 
-            var serializedODataRepsonse = JsonConvert.SerializeObject(oDataResponse);
+            var serializedODataRepsonse = JsonConvert.SerializeObject(oDataResponse, new Newtonsoft.Json.Converters.StringEnumConverter());
             var client = Utilities.GetTestClient(serializedODataRepsonse);
 
             // Act
@@ -308,7 +308,7 @@ namespace Microsoft.PowerBI.Common.Api.Test
             var serializedODataRepsonse = $@"{{
   ""@odata.context"":""http://example.net/v2.0/myorg/gatewayPolicy"",
   ""id"":""{tenantId}"",
-  ""policy"":0
+  ""policy"":""None""
 }}";
 
             var client = Utilities.GetTestClient(serializedODataRepsonse);
@@ -318,6 +318,29 @@ namespace Microsoft.PowerBI.Common.Api.Test
 
             // Assert
             result.TenantObjectId.Should().Be(tenantId);
+            result.Policy.Should().Be(TenantPolicy.None);
+        }
+
+        [TestMethod]
+        public async Task GetOnPremisesDataGatewayTenantPolicyCanBeSerializedAndDeSerialized()
+        {
+            // Arrange
+            var tenantId = Guid.NewGuid().ToString();
+            var oDataResponse = new ODataResponseGatewayTenant
+            {
+                ODataContext = "http://example.net/v2.0/myorg/gatewayPolicy",
+                TenantObjectId = tenantId,
+                Policy = TenantPolicy.None
+            };
+
+            var serializedODataRepsonse = JsonConvert.SerializeObject(oDataResponse, new Newtonsoft.Json.Converters.StringEnumConverter());
+            var client = Utilities.GetTestClient(serializedODataRepsonse);
+
+            // Act
+            var result = await client.GetTenantPolicy();
+
+            // Assert
+            oDataResponse.Should().BeEquivalentTo(result);
         }
 
         [TestMethod]
@@ -355,33 +378,11 @@ namespace Microsoft.PowerBI.Common.Api.Test
                 }
             };
 
-            var serializedODataRepsonse = JsonConvert.SerializeObject(oDataResponse);
+            var serializedODataRepsonse = JsonConvert.SerializeObject(oDataResponse, new Newtonsoft.Json.Converters.StringEnumConverter());
             var client = Utilities.GetTestClient(serializedODataRepsonse);
 
             // Act
             var result = await client.GetInstallerPrincipals(GatewayType.Personal);
-
-            // Assert
-            oDataResponse.Should().BeEquivalentTo(result);
-        }
-
-        [TestMethod]
-        public async Task GetOnPremisesDataGatewayTenantPolicyCanBeSerializedAndDeSerialized()
-        {
-            // Arrange
-            var tenantId = Guid.NewGuid().ToString();
-            var oDataResponse = new ODataResponseGatewayTenant
-            {
-                ODataContext = "http://example.net/v2.0/myorg/gatewayPolicy",
-                TenantObjectId = tenantId,
-                Policy = TenantPolicy.None
-            };
-
-            var serializedODataRepsonse = JsonConvert.SerializeObject(oDataResponse);
-            var client = Utilities.GetTestClient(serializedODataRepsonse);
-
-            // Act
-            var result = await client.GetTenantPolicy();
 
             // Assert
             oDataResponse.Should().BeEquivalentTo(result);

--- a/src/Common/Common.Api/Gateways/GatewayClient.cs
+++ b/src/Common/Common.Api/Gateways/GatewayClient.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Runtime.Serialization.Json;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.PowerBI.Common.Abstractions.Utilities;
@@ -15,8 +14,11 @@ using Microsoft.PowerBI.Common.Abstractions.Interfaces;
 using Microsoft.PowerBI.Common.Api.Gateways.Entities;
 using Microsoft.PowerBI.Common.Api.Gateways.Interfaces;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System.IO;
 
 using static System.FormattableString;
+
 
 namespace Microsoft.PowerBI.Common.Api.Gateways
 {
@@ -212,8 +214,14 @@ namespace Microsoft.PowerBI.Common.Api.Gateways
 
         private async Task<T> DeserializeResponseContent<T>(HttpResponseMessage response)
         {
-            var serializer = new DataContractJsonSerializer(typeof(T));
-            return (T)serializer.ReadObject(await response.Content.ReadAsStreamAsync());
+            var serializer = new JsonSerializer();
+            serializer.Converters.Add(new StringEnumConverter());
+
+            using (var sr = new StreamReader(await response.Content.ReadAsStreamAsync()))
+            using (var jsonTextReader = new JsonTextReader(sr))
+            {
+                return serializer.Deserialize<T>(jsonTextReader);
+            }
         }
     }
 }

--- a/src/Common/Common.Api/Gateways/GatewayClient.cs
+++ b/src/Common/Common.Api/Gateways/GatewayClient.cs
@@ -5,18 +5,17 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.PowerBI.Common.Abstractions.Utilities;
 using Microsoft.PowerBI.Common.Abstractions.Interfaces;
+using Microsoft.PowerBI.Common.Abstractions.Utilities;
 using Microsoft.PowerBI.Common.Api.Gateways.Entities;
 using Microsoft.PowerBI.Common.Api.Gateways.Interfaces;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
-using System.IO;
-
 using static System.FormattableString;
 
 


### PR DESCRIPTION
Enum-types coming from PowerBI are serialized as strings rather than their underlying numeric value. To fix this, we moved to using a different deserializer that can automatically convert strings to enums (newtonsoft).