### PR TITLE
Update Newtonsoft.json version to the latest for the Profile project to resolve NuGet dependency issue

### DIFF
--- a/src/Modules/Profile/Commands.Profile/Commands.Profile.csproj
+++ b/src/Modules/Profile/Commands.Profile/Commands.Profile.csproj
@@ -33,6 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Newtonsoft.Json is included to ensure this module loads a newer version than what's required by the Power BI SDK -->
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="PowerShellStandard.Library" Version="3.0.0-preview-01">
       <PrivateAssets>All</PrivateAssets>

--- a/src/Modules/Profile/Commands.Profile/Commands.Profile.csproj
+++ b/src/Modules/Profile/Commands.Profile/Commands.Profile.csproj
@@ -33,6 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="PowerShellStandard.Library" Version="3.0.0-preview-01">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
The Commands.Profile project has a dependency on Microsoft.Rest.ClientRuntime. This package depends on an older version of Newtonsoft.json than the version required by the Power BI SDK. This means that if the Profile module is loaded before any of the other modules, calls to the SDK will fail with the error:
{"Attempted to access an element as a type incompatible with the array."}.

Having the Commands.Profile project explicitly depend on the latest version of Newtonsoft.json resolves this issue. The other cmdlet projects depend on the Commands.Profile project, so this ensures they correctly load the latest version of Newtonsoft.json.