### PR TITLE
Fix small documentation bugs

### DIFF
--- a/src/Modules/OnPremisesDataGateway/Commands.OnPremisesDataGateway/SetOnPremisesDataGatewayInstaller.cs
+++ b/src/Modules/OnPremisesDataGateway/Commands.OnPremisesDataGateway/SetOnPremisesDataGatewayInstaller.cs
@@ -17,7 +17,7 @@ namespace Microsoft.PowerBI.Commands.OnPremisesDataGateway
         public const string CmdletVerb = VerbsCommon.Set;
 
         [Alias("Users")]
-        [Parameter()]
+        [Parameter(Mandatory = true)]
         public string[] PrincipalObjectIds { get; set; }
 
         [Parameter(Mandatory = true)]

--- a/src/Modules/OnPremisesDataGateway/Commands.OnPremisesDataGateway/help/Set-OnPremisesDataGatewayCluster.md
+++ b/src/Modules/OnPremisesDataGateway/Commands.OnPremisesDataGateway/help/Set-OnPremisesDataGatewayCluster.md
@@ -26,7 +26,7 @@ Set attributes of an existing gateway cluster
 
 ### Example 1
 ```powershell
-PS C:\> Set-OnPremisesDataGatewayCluster -GatewayClusterId DC8F2C49-5731-4B27-966B-3DB5094C2E77 -AllowCloudDatasourceRefresh true
+PS C:\> Set-OnPremisesDataGatewayCluster -GatewayClusterId DC8F2C49-5731-4B27-966B-3DB5094C2E77 -AllowCloudDatasourceRefresh $true
 ```
 
 Allow Power BI cloud datasource refresh on the cluster with ID DC8F2C49-5731-4B27-966B-3DB5094C2E77

--- a/src/Modules/OnPremisesDataGateway/Commands.OnPremisesDataGateway/help/Set-OnPremisesDataGatewayInstaller.md
+++ b/src/Modules/OnPremisesDataGateway/Commands.OnPremisesDataGateway/help/Set-OnPremisesDataGatewayInstaller.md
@@ -13,7 +13,7 @@ Modify list of users who can install and register new gateways on the tenant
 ## SYNTAX
 
 ```
-Set-OnPremisesDataGatewayInstaller [-PrincipalObjectIds <String[]>] -Operation <OperationType>
+Set-OnPremisesDataGatewayInstaller -PrincipalObjectIds <String[]> -Operation <OperationType>
  -GatewayType <GatewayType> [<CommonParameters>]
 ```
 
@@ -82,7 +82,7 @@ Type: String[]
 Parameter Sets: (All)
 Aliases: Users
 
-Required: False
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False


### PR DESCRIPTION
1. Make PrincipalObjectIds mandatory
2. Use correct value for true boolean in powershell (i.e. $true)