### PR TITLE
Use workspace ID when exporting a report

### DIFF
--- a/examples/CopyWorkspaceSampleScript.ps1
+++ b/examples/CopyWorkspaceSampleScript.ps1
@@ -137,7 +137,12 @@ Foreach ($report in $reports) {
 
     Write-Host "== Exporting $report_name with id: $report_id to $temp_path"
     try {
-        Export-PowerBIReport -Id $report_id -WorkspaceId $source_workspace_ID -OutFile "$temp_path" -ErrorAction Stop
+        if ($source_workspace_ID -eq "me") {
+            Export-PowerBIReport -Id $report_id -OutFile "$temp_path" -ErrorAction Stop
+        }
+        else {
+            Export-PowerBIReport -Id $report_id -WorkspaceId $source_workspace_ID -OutFile "$temp_path" -ErrorAction Stop
+        }
     }
     catch {
         Write-Warning "= This report and dataset cannot be copied, skipping. This is expected for most workspaces."

--- a/examples/CopyWorkspaceSampleScript.ps1
+++ b/examples/CopyWorkspaceSampleScript.ps1
@@ -137,7 +137,7 @@ Foreach ($report in $reports) {
 
     Write-Host "== Exporting $report_name with id: $report_id to $temp_path"
     try {
-        Export-PowerBIReport -Id $report_id -OutFile "$temp_path" -ErrorAction Stop
+        Export-PowerBIReport -Id $report_id -WorkspaceId $source_workspace_ID -OutFile "$temp_path" -ErrorAction Stop
     }
     catch {
         Write-Warning "= This report and dataset cannot be copied, skipping. This is expected for most workspaces."


### PR DESCRIPTION
Report export didnt work without workspace ID when using a global admin account to export reports.