### PR TITLE
Allow adding apps and groups to workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ Add a user to a given workspace:
 Add-PowerBIWorkspaceUser -Scope Organization -Id 3244f1c1-01cf-457f-9383-6035e4950fdc -UserEmailAddress john@contoso.com -AccessRight Admin
 ```
 
-### Add new application to workspace
+### Add new service principal to workspace
 
-Add an application to a given workspace:
+Add a service principal to a given workspace:
 
 ```powershell
 Add-PowerBIWorkspaceUser -WorkspaceId 3244f1c1-01cf-457f-9383-6035e4950fdc -Identifier "09934a8f-5066-44b2-91a6-f4987c76ae9e" -AccessRight Contibutor -PrincipalType App

--- a/README.md
+++ b/README.md
@@ -103,6 +103,22 @@ Add a user to a given workspace:
 Add-PowerBIWorkspaceUser -Scope Organization -Id 3244f1c1-01cf-457f-9383-6035e4950fdc -UserEmailAddress john@contoso.com -AccessRight Admin
 ```
 
+### Add new application to workspace
+
+Add an application to a given workspace:
+
+```powershell
+Add-PowerBIWorkspaceUser -WorkspaceId 3244f1c1-01cf-457f-9383-6035e4950fdc -Identifier "09934a8f-5066-44b2-91a6-f4987c76ae9e" -AccessRight Contibutor -PrincipalType App
+```
+
+### Add new group to workspace
+
+Add a group to a given workspace:
+
+```powershell
+Add-PowerBIWorkspaceUser -WorkspaceId 3244f1c1-01cf-457f-9383-6035e4950fdc -Identifier "ddc3ecc2-e17e-4353-9b42-964b55500e0f" -AccessRight Contibutor -PrincipalType Group
+```
+
 ### Remove a user from a given workspace
 
 Remove user's permissions from a given workspace:

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Add-PowerBIWorkspaceUser -Scope Organization -Id 3244f1c1-01cf-457f-9383-6035e49
 Add a service principal to a given workspace:
 
 ```powershell
-Add-PowerBIWorkspaceUser -WorkspaceId 3244f1c1-01cf-457f-9383-6035e4950fdc -Identifier "09934a8f-5066-44b2-91a6-f4987c76ae9e" -AccessRight Contibutor -PrincipalType App
+Add-PowerBIWorkspaceUser -WorkspaceId 3244f1c1-01cf-457f-9383-6035e4950fdc -Identifier "09934a8f-5066-44b2-91a6-f4987c76ae9e" -AccessRight Contributor -PrincipalType App
 ```
 
 ### Add new group to workspace
@@ -116,7 +116,7 @@ Add-PowerBIWorkspaceUser -WorkspaceId 3244f1c1-01cf-457f-9383-6035e4950fdc -Iden
 Add a group to a given workspace:
 
 ```powershell
-Add-PowerBIWorkspaceUser -WorkspaceId 3244f1c1-01cf-457f-9383-6035e4950fdc -Identifier "ddc3ecc2-e17e-4353-9b42-964b55500e0f" -AccessRight Contibutor -PrincipalType Group
+Add-PowerBIWorkspaceUser -WorkspaceId 3244f1c1-01cf-457f-9383-6035e4950fdc -Identifier "ddc3ecc2-e17e-4353-9b42-964b55500e0f" -AccessRight Contributor -PrincipalType Group
 ```
 
 ### Remove a user from a given workspace

--- a/src/Common/Common.Api/Workspaces/WorkspaceUser.cs
+++ b/src/Common/Common.Api/Workspaces/WorkspaceUser.cs
@@ -21,11 +21,12 @@ namespace Microsoft.PowerBI.Common.Api.Workspaces
         {
             if (string.IsNullOrEmpty(groupUserAccessRight.PrincipalType))
             {
+                // Principal type is not set, default to adding a user by their email address.
                 return new WorkspaceUser { AccessRight = groupUserAccessRight.GroupUserAccessRightProperty, UserPrincipalName = groupUserAccessRight.EmailAddress };
             }
             else
             {
-                // Principal is either an App, Group, or User specified by an OID.
+                // Principal type is explicitly set.
                 return new WorkspaceUser { AccessRight = groupUserAccessRight.GroupUserAccessRightProperty, Identifier = groupUserAccessRight.Identifier, PrincipalType = groupUserAccessRight.PrincipalType };
             }
         }
@@ -34,11 +35,12 @@ namespace Microsoft.PowerBI.Common.Api.Workspaces
         {
             if (string.IsNullOrEmpty(workspaceUser.PrincipalType))
             {
+                // Principal type is not set, default to adding a user by their email address.
                 return new GroupUserAccessRight { GroupUserAccessRightProperty = workspaceUser.AccessRight, EmailAddress = workspaceUser.UserPrincipalName };
             }
             else
             {
-                // Principal is either an App, Group, or User specified by an OID.
+                // Principal type is explicitly set.
                 return new GroupUserAccessRight { GroupUserAccessRightProperty = workspaceUser.AccessRight, Identifier = workspaceUser.Identifier, PrincipalType = workspaceUser.PrincipalType };
             }
         }

--- a/src/Common/Common.Api/Workspaces/WorkspaceUser.cs
+++ b/src/Common/Common.Api/Workspaces/WorkspaceUser.cs
@@ -13,14 +13,34 @@ namespace Microsoft.PowerBI.Common.Api.Workspaces
 
         public string UserPrincipalName { get; set; }
 
+        public string Identifier { get; set; }
+
+        public string PrincipalType { get; set; }
+
         public static implicit operator WorkspaceUser(GroupUserAccessRight groupUserAccessRight)
         {
-            return new WorkspaceUser { AccessRight = groupUserAccessRight.GroupUserAccessRightProperty, UserPrincipalName = groupUserAccessRight.EmailAddress };
+            if (string.IsNullOrEmpty(groupUserAccessRight.PrincipalType))
+            {
+                return new WorkspaceUser { AccessRight = groupUserAccessRight.GroupUserAccessRightProperty, UserPrincipalName = groupUserAccessRight.EmailAddress };
+            }
+            else
+            {
+                // Principal is either an App, Group, or User specified by an OID.
+                return new WorkspaceUser { AccessRight = groupUserAccessRight.GroupUserAccessRightProperty, Identifier = groupUserAccessRight.Identifier, PrincipalType = groupUserAccessRight.PrincipalType };
+            }
         }
 
         public static implicit operator GroupUserAccessRight(WorkspaceUser workspaceUser)
         {
-            return new GroupUserAccessRight { GroupUserAccessRightProperty = workspaceUser.AccessRight, EmailAddress = workspaceUser.UserPrincipalName };
+            if (string.IsNullOrEmpty(workspaceUser.PrincipalType))
+            {
+                return new GroupUserAccessRight { GroupUserAccessRightProperty = workspaceUser.AccessRight, EmailAddress = workspaceUser.UserPrincipalName };
+            }
+            else
+            {
+                // Principal is either an App, Group, or User specified by an OID.
+                return new GroupUserAccessRight { GroupUserAccessRightProperty = workspaceUser.AccessRight, Identifier = workspaceUser.Identifier, PrincipalType = workspaceUser.PrincipalType };
+            }
         }
     }
 }

--- a/src/Common/Common.Api/Workspaces/WorkspaceUser.cs
+++ b/src/Common/Common.Api/Workspaces/WorkspaceUser.cs
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+using System;
 using Microsoft.PowerBI.Api.V2.Models;
 
 namespace Microsoft.PowerBI.Common.Api.Workspaces
@@ -15,33 +16,33 @@ namespace Microsoft.PowerBI.Common.Api.Workspaces
 
         public string Identifier { get; set; }
 
-        public string PrincipalType { get; set; }
+        public WorkspaceUserPrincipalType? PrincipalType { get; set; }
 
         public static implicit operator WorkspaceUser(GroupUserAccessRight groupUserAccessRight)
         {
-            if (string.IsNullOrEmpty(groupUserAccessRight.PrincipalType))
+            if (!string.IsNullOrEmpty(groupUserAccessRight.PrincipalType) && Enum.TryParse(groupUserAccessRight.PrincipalType, out WorkspaceUserPrincipalType principalType))
             {
-                // Principal type is not set, default to adding a user by their email address.
-                return new WorkspaceUser { AccessRight = groupUserAccessRight.GroupUserAccessRightProperty, UserPrincipalName = groupUserAccessRight.EmailAddress };
+                // Principal type is explicitly set.
+                return new WorkspaceUser { AccessRight = groupUserAccessRight.GroupUserAccessRightProperty, Identifier = groupUserAccessRight.Identifier, PrincipalType = principalType };
             }
             else
             {
-                // Principal type is explicitly set.
-                return new WorkspaceUser { AccessRight = groupUserAccessRight.GroupUserAccessRightProperty, Identifier = groupUserAccessRight.Identifier, PrincipalType = groupUserAccessRight.PrincipalType };
+                // Principal type is not set, default to adding a user by their email address.
+                return new WorkspaceUser { AccessRight = groupUserAccessRight.GroupUserAccessRightProperty, UserPrincipalName = groupUserAccessRight.EmailAddress };
             }
         }
 
         public static implicit operator GroupUserAccessRight(WorkspaceUser workspaceUser)
         {
-            if (string.IsNullOrEmpty(workspaceUser.PrincipalType))
+            if (workspaceUser.PrincipalType.HasValue)
             {
-                // Principal type is not set, default to adding a user by their email address.
-                return new GroupUserAccessRight { GroupUserAccessRightProperty = workspaceUser.AccessRight, EmailAddress = workspaceUser.UserPrincipalName };
+                // Principal type is explicitly set.
+                return new GroupUserAccessRight { GroupUserAccessRightProperty = workspaceUser.AccessRight, Identifier = workspaceUser.Identifier, PrincipalType = workspaceUser.PrincipalType.ToString() };
             }
             else
             {
-                // Principal type is explicitly set.
-                return new GroupUserAccessRight { GroupUserAccessRightProperty = workspaceUser.AccessRight, Identifier = workspaceUser.Identifier, PrincipalType = workspaceUser.PrincipalType };
+                // Principal type is not set, default to adding a user by their email address.
+                return new GroupUserAccessRight { GroupUserAccessRightProperty = workspaceUser.AccessRight, EmailAddress = workspaceUser.UserPrincipalName };
             }
         }
     }

--- a/src/Common/Common.Api/Workspaces/WorkspaceUserPrincipalType.cs
+++ b/src/Common/Common.Api/Workspaces/WorkspaceUserPrincipalType.cs
@@ -1,0 +1,14 @@
+﻿/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+namespace Microsoft.PowerBI.Common.Api.Workspaces
+{
+    public enum WorkspaceUserPrincipalType
+    {
+        App,
+        Group,
+        User
+    }
+}

--- a/src/Modules/Workspaces/Commands.Workspaces.Test/AddPowerBIWorkspaceUserTests.cs
+++ b/src/Modules/Workspaces/Commands.Workspaces.Test/AddPowerBIWorkspaceUserTests.cs
@@ -96,10 +96,10 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         public void EndToEndAddPowerBIWorkspaceUser_ExplicitPrincipalType()
         {
             // Set this to the identifier of the object (App, Group, or User) you want to add to the workspace.
-            const string ObjectId = "b6a32eb9-17b6-4c16-82ae-e97d3c09bfe4";
+            const string ObjectId = "";
 
             // Optionally specify the Id of an existing workspace. Otherwise, the first returned workspace will be used.
-            const string WorkspaceId = "8e6fb832-c583-4907-bdfe-576fc4954831";
+            const string WorkspaceId = "";
 
             // The type of the object being added to the workspace.
             const WorkspaceUserPrincipalType PrincipalType = WorkspaceUserPrincipalType.App;
@@ -335,8 +335,8 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         {
             // Arrange
             var workspaceId = Guid.NewGuid();
-            var groupName = "groupName";
-            var user = new WorkspaceUser { Identifier = groupName, AccessRight = WorkspaceUserAccessRight.Member.ToString(), PrincipalType = WorkspaceUserPrincipalType.Group };
+            var groupId = Guid.NewGuid();
+            var user = new WorkspaceUser { Identifier = groupId.ToString(), AccessRight = WorkspaceUserAccessRight.Member.ToString(), PrincipalType = WorkspaceUserPrincipalType.Group };
             var expectedResponse = new object();
             var client = new Mock<IPowerBIApiClient>();
             client.Setup(x => x.Workspaces

--- a/src/Modules/Workspaces/Commands.Workspaces.Test/AddPowerBIWorkspaceUserTests.cs
+++ b/src/Modules/Workspaces/Commands.Workspaces.Test/AddPowerBIWorkspaceUserTests.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
-using Microsoft.PowerBI.Api.V2.Models;
 using Microsoft.PowerBI.Commands.Common.Test;
 using Microsoft.PowerBI.Commands.Profile.Test;
 using Microsoft.PowerBI.Common.Abstractions;
@@ -97,10 +96,10 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         public void EndToEndAddPowerBIWorkspaceUser_ExplicitPrincipalType()
         {
             // Set this to the identifier of the object (App, Group, or User) you want to add to the workspace.
-            const string ObjectId = "";
+            const string ObjectId = "b6a32eb9-17b6-4c16-82ae-e97d3c09bfe4";
 
             // Optionally specify the Id of an existing workspace. Otherwise, the first returned workspace will be used.
-            const string WorkspaceId = "";
+            const string WorkspaceId = "8e6fb832-c583-4907-bdfe-576fc4954831";
 
             // The type of the object being added to the workspace.
             const WorkspaceUserPrincipalType PrincipalType = WorkspaceUserPrincipalType.App;
@@ -207,7 +206,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
                 Id = workspaceId,
                 UserPrincipalName = user.UserPrincipalName,
                 AccessRight = WorkspaceUserAccessRight.Member,
-                ParameterSet = "Id",
+                ParameterSet = "UserEmailWithId",
             };
 
             // Act
@@ -235,7 +234,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
                 Workspace = workspace,
                 UserPrincipalName = user.UserPrincipalName,
                 AccessRight = WorkspaceUserAccessRight.Member,
-                ParameterSet = "Workspace",
+                ParameterSet = "UserEmailWithWorkspace",
             };
 
             // Act
@@ -263,7 +262,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
                 Id = workspaceId,
                 UserPrincipalName = user.UserPrincipalName,
                 AccessRight = WorkspaceUserAccessRight.Member,
-                ParameterSet = "Id",
+                ParameterSet = "UserEmailWithId",
             };
 
             // Act
@@ -274,12 +273,12 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         }
 
         [TestMethod]
-        public void AddPowerBIWorkspaceUser_PrincipalTypeApp()
+        public void AddPowerBIWorkspaceUser_PrincipalTypeApp_WithId()
         {
             // Arrange
             var workspaceId = Guid.NewGuid();
             var principalId = Guid.NewGuid();
-            var user = new WorkspaceUser { Identifier = principalId.ToString(), AccessRight = WorkspaceUserAccessRight.Member.ToString(), PrincipalType = PrincipalType.App };
+            var user = new WorkspaceUser { Identifier = principalId.ToString(), AccessRight = WorkspaceUserAccessRight.Member.ToString(), PrincipalType = WorkspaceUserPrincipalType.App };
             var expectedResponse = new object();
             var client = new Mock<IPowerBIApiClient>();
             client.Setup(x => x.Workspaces
@@ -292,7 +291,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
                 Identifier = user.Identifier,
                 AccessRight = WorkspaceUserAccessRight.Member,
                 PrincipalType = WorkspaceUserPrincipalType.App,
-                ParameterSet = "Id",
+                ParameterSet = "PrincipalTypeWithId",
             };
 
             // Act
@@ -303,12 +302,41 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         }
 
         [TestMethod]
-        public void AddPowerBIWorkspaceUser_PrincipalTypeGroup()
+        public void AddPowerBIWorkspaceUser_PrincipalTypeApp_WithWorkspace()
+        {
+            // Arrange
+            var workspace = new Workspace { Id = Guid.NewGuid() };
+            var principalId = Guid.NewGuid();
+            var user = new WorkspaceUser { Identifier = principalId.ToString(), AccessRight = WorkspaceUserAccessRight.Member.ToString(), PrincipalType = WorkspaceUserPrincipalType.App };
+            var expectedResponse = new object();
+            var client = new Mock<IPowerBIApiClient>();
+            client.Setup(x => x.Workspaces
+                .AddWorkspaceUser(workspace.Id, It.Is<WorkspaceUser>(u => u.Identifier == user.Identifier && u.AccessRight == user.AccessRight && u.PrincipalType == user.PrincipalType)))
+                .Returns(expectedResponse);
+            var initFactory = new TestPowerBICmdletInitFactory(client.Object);
+            var cmdlet = new AddPowerBIWorkspaceUser(initFactory)
+            {
+                Workspace = workspace,
+                Identifier = user.Identifier,
+                AccessRight = WorkspaceUserAccessRight.Member,
+                PrincipalType = WorkspaceUserPrincipalType.App,
+                ParameterSet = "PrincipalTypeWithWorkspace",
+            };
+
+            // Act
+            cmdlet.InvokePowerBICmdlet();
+
+            // Assert
+            TestUtilities.AssertExpectedUnitTestResults(expectedResponse, client, initFactory);
+        }
+
+        [TestMethod]
+        public void AddPowerBIWorkspaceUser_PrincipalTypeGroup_WithId()
         {
             // Arrange
             var workspaceId = Guid.NewGuid();
             var groupName = "groupName";
-            var user = new WorkspaceUser { Identifier = groupName, AccessRight = WorkspaceUserAccessRight.Member.ToString(), PrincipalType = PrincipalType.Group };
+            var user = new WorkspaceUser { Identifier = groupName, AccessRight = WorkspaceUserAccessRight.Member.ToString(), PrincipalType = WorkspaceUserPrincipalType.Group };
             var expectedResponse = new object();
             var client = new Mock<IPowerBIApiClient>();
             client.Setup(x => x.Workspaces
@@ -321,7 +349,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
                 Identifier = user.Identifier,
                 AccessRight = WorkspaceUserAccessRight.Member,
                 PrincipalType = WorkspaceUserPrincipalType.Group,
-                ParameterSet = "Id",
+                ParameterSet = "PrincipalTypeWithId",
             };
 
             // Act

--- a/src/Modules/Workspaces/Commands.Workspaces.Test/AddPowerBIWorkspaceUserTests.cs
+++ b/src/Modules/Workspaces/Commands.Workspaces.Test/AddPowerBIWorkspaceUserTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
+using Microsoft.PowerBI.Api.V2.Models;
 using Microsoft.PowerBI.Commands.Common.Test;
 using Microsoft.PowerBI.Commands.Profile.Test;
 using Microsoft.PowerBI.Common.Abstractions;
@@ -77,6 +78,52 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
                     { nameof(AddPowerBIWorkspaceUser.Id), workspace.Id }, 
                     { nameof(AddPowerBIWorkspaceUser.UserPrincipalName), emailAddress },
                     { nameof(AddPowerBIWorkspaceUser.AccessRight), WorkspaceUserAccessRight.Admin }
+                };
+                ps.AddCommand(Cmdlet).AddParameters(parameters);
+
+                // Act
+                var results = ps.Invoke();
+
+                // Assert
+                TestUtilities.AssertNoCmdletErrors(ps);
+                Assert.IsNotNull(results);
+                Assert.IsTrue(results.Any());
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("Interactive")]
+        [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        public void EndToEndAddPowerBIWorkspaceUser_ExplicitPrincipalType()
+        {
+            // Set this to the identifier of the object (App, Group, or User) you want to add to the workspace.
+            const string ObjectId = "";
+
+            // Optionally specify the Id of an existing workspace. Otherwise, the first returned workspace will be used.
+            const string WorkspaceId = "";
+
+            // The type of the object being added to the workspace.
+            const WorkspaceUserPrincipalType PrincipalType = WorkspaceUserPrincipalType.App;
+
+            using (var ps = System.Management.Automation.PowerShell.Create())
+            {
+                // Arrange
+                ProfileTestUtilities.ConnectToPowerBI(ps, environment: PowerBIEnvironmentType.Public);
+
+                string workspaceId = WorkspaceId;
+                if (string.IsNullOrEmpty(WorkspaceId))
+                {
+                    var workspace = WorkspacesTestUtilities.GetFirstWorkspace(ps, PowerBIUserScope.Individual);
+                    WorkspacesTestUtilities.AssertShouldContinueIndividualTest(workspace);
+                    workspaceId = workspace.Id.ToString();
+                }
+
+                var parameters = new Dictionary<string, object>()
+                {
+                    { nameof(AddPowerBIWorkspaceUser.Id), workspaceId }, 
+                    { nameof(AddPowerBIWorkspaceUser.PrincipalType), PrincipalType },
+                    { nameof(AddPowerBIWorkspaceUser.Identifier), ObjectId },
+                    { nameof(AddPowerBIWorkspaceUser.AccessRight), WorkspaceUserAccessRight.Contributor }
                 };
                 ps.AddCommand(Cmdlet).AddParameters(parameters);
 
@@ -216,6 +263,64 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
                 Id = workspaceId,
                 UserPrincipalName = user.UserPrincipalName,
                 AccessRight = WorkspaceUserAccessRight.Member,
+                ParameterSet = "Id",
+            };
+
+            // Act
+            cmdlet.InvokePowerBICmdlet();
+
+            // Assert
+            TestUtilities.AssertExpectedUnitTestResults(expectedResponse, client, initFactory);
+        }
+
+        [TestMethod]
+        public void AddPowerBIWorkspaceUser_PrincipalTypeApp()
+        {
+            // Arrange
+            var workspaceId = Guid.NewGuid();
+            var principalId = Guid.NewGuid();
+            var user = new WorkspaceUser { Identifier = principalId.ToString(), AccessRight = WorkspaceUserAccessRight.Member.ToString(), PrincipalType = PrincipalType.App };
+            var expectedResponse = new object();
+            var client = new Mock<IPowerBIApiClient>();
+            client.Setup(x => x.Workspaces
+                .AddWorkspaceUser(workspaceId, It.Is<WorkspaceUser>(u => u.Identifier == user.Identifier && u.AccessRight == user.AccessRight && u.PrincipalType == user.PrincipalType)))
+                .Returns(expectedResponse);
+            var initFactory = new TestPowerBICmdletInitFactory(client.Object);
+            var cmdlet = new AddPowerBIWorkspaceUser(initFactory)
+            {
+                Id = workspaceId,
+                Identifier = user.Identifier,
+                AccessRight = WorkspaceUserAccessRight.Member,
+                PrincipalType = WorkspaceUserPrincipalType.App,
+                ParameterSet = "Id",
+            };
+
+            // Act
+            cmdlet.InvokePowerBICmdlet();
+
+            // Assert
+            TestUtilities.AssertExpectedUnitTestResults(expectedResponse, client, initFactory);
+        }
+
+        [TestMethod]
+        public void AddPowerBIWorkspaceUser_PrincipalTypeGroup()
+        {
+            // Arrange
+            var workspaceId = Guid.NewGuid();
+            var groupName = "groupName";
+            var user = new WorkspaceUser { Identifier = groupName, AccessRight = WorkspaceUserAccessRight.Member.ToString(), PrincipalType = PrincipalType.Group };
+            var expectedResponse = new object();
+            var client = new Mock<IPowerBIApiClient>();
+            client.Setup(x => x.Workspaces
+                .AddWorkspaceUser(workspaceId, It.Is<WorkspaceUser>(u => u.Identifier == user.Identifier && u.AccessRight == user.AccessRight && u.PrincipalType == user.PrincipalType)))
+                .Returns(expectedResponse);
+            var initFactory = new TestPowerBICmdletInitFactory(client.Object);
+            var cmdlet = new AddPowerBIWorkspaceUser(initFactory)
+            {
+                Id = workspaceId,
+                Identifier = user.Identifier,
+                AccessRight = WorkspaceUserAccessRight.Member,
+                PrincipalType = WorkspaceUserPrincipalType.Group,
                 ParameterSet = "Id",
             };
 

--- a/src/Modules/Workspaces/Commands.Workspaces/AddPowerBIWorkspaceUser.cs
+++ b/src/Modules/Workspaces/Commands.Workspaces/AddPowerBIWorkspaceUser.cs
@@ -55,7 +55,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces
 
         [Parameter(Mandatory = true, ParameterSetName = PrincipalTypeWithIdParameterSetName)]
         [Parameter(Mandatory = true, ParameterSetName = PrincipalTypeWithWorkspaceParameterSetName)]
-        public WorkspaceUserPrincipalType? PrincipalType { get; set; }
+        public WorkspaceUserPrincipalType PrincipalType { get; set; }
 
         [Parameter(Mandatory = true, ParameterSetName = PrincipalTypeWithIdParameterSetName)]
         [Parameter(Mandatory = true, ParameterSetName = PrincipalTypeWithWorkspaceParameterSetName)]

--- a/src/Modules/Workspaces/Commands.Workspaces/AddPowerBIWorkspaceUser.cs
+++ b/src/Modules/Workspaces/Commands.Workspaces/AddPowerBIWorkspaceUser.cs
@@ -12,15 +12,18 @@ using Microsoft.PowerBI.Common.Client;
 
 namespace Microsoft.PowerBI.Commands.Workspaces
 {
-    [Cmdlet(CmdletVerb, CmdletName, DefaultParameterSetName = IdParameterSetName)]
+    [Cmdlet(CmdletVerb, CmdletName, DefaultParameterSetName = UserEmailWithIdParameterSetName)]
     [Alias("Add-PowerBIGroupUser")]
     public class AddPowerBIWorkspaceUser : PowerBIClientCmdlet, IUserScope
     {
         public const string CmdletName = "PowerBIWorkspaceUser";
         public const string CmdletVerb = VerbsCommon.Add;
 
-        private const string IdParameterSetName = "Id";
-        private const string WorkspaceParameterSetName = "Workspace";
+        private const string UserEmailWithIdParameterSetName = "UserEmailWithId";
+        private const string UserEmailWithWorkspaceParameterSetName = "UserEmailWithWorkspace";
+
+        private const string PrincipalTypeWithIdParameterSetName = "PrincipalTypeWithId";
+        private const string PrincipalTypeWithWorkspaceParameterSetName = "PrincipalTypeWithWorkspace";
 
         public AddPowerBIWorkspaceUser() : base() { }
 
@@ -31,14 +34,13 @@ namespace Microsoft.PowerBI.Commands.Workspaces
         [Parameter(Mandatory = false)]
         public PowerBIUserScope Scope { get; set; } = PowerBIUserScope.Individual;
 
-        [Parameter(Mandatory = true, ParameterSetName = IdParameterSetName, ValueFromPipelineByPropertyName = true)]
+        [Parameter(Mandatory = true, ParameterSetName = UserEmailWithIdParameterSetName, ValueFromPipelineByPropertyName = true)]
+        [Parameter(Mandatory = true, ParameterSetName = PrincipalTypeWithIdParameterSetName, ValueFromPipelineByPropertyName = true)]
         [Alias("GroupId", "WorkspaceId")]
         public Guid Id { get; set; }
 
-        [Parameter(Mandatory = false)]
-        public string Identifier { get; set; }
-
-        [Parameter(Mandatory = false)]
+        [Parameter(Mandatory = true, ParameterSetName = UserEmailWithIdParameterSetName)]
+        [Parameter(Mandatory = true, ParameterSetName = UserEmailWithWorkspaceParameterSetName)]
         [Alias("UserEmailAddress")]
         public string UserPrincipalName { get; set; }
 
@@ -46,12 +48,19 @@ namespace Microsoft.PowerBI.Commands.Workspaces
         [Alias("UserAccessRight")]
         public WorkspaceUserAccessRight AccessRight { get; set; }
 
-        [Parameter(Mandatory = false)]
-        public WorkspaceUserPrincipalType? PrincipalType { get; set; }
-
-        [Parameter(Mandatory = true, ParameterSetName = WorkspaceParameterSetName)]
+        [Parameter(Mandatory = true, ParameterSetName = UserEmailWithWorkspaceParameterSetName)]
+        [Parameter(Mandatory = true, ParameterSetName = PrincipalTypeWithWorkspaceParameterSetName)]
         [Alias("Group")]
         public Workspace Workspace { get; set; }
+
+        [Parameter(Mandatory = true, ParameterSetName = PrincipalTypeWithIdParameterSetName)]
+        [Parameter(Mandatory = true, ParameterSetName = PrincipalTypeWithWorkspaceParameterSetName)]
+        public WorkspaceUserPrincipalType? PrincipalType { get; set; }
+
+        [Parameter(Mandatory = true, ParameterSetName = PrincipalTypeWithIdParameterSetName)]
+        [Parameter(Mandatory = true, ParameterSetName = PrincipalTypeWithWorkspaceParameterSetName)]
+        [Alias("PrincipalId")]
+        public string Identifier { get; set; }
 
         #endregion
 
@@ -67,13 +76,13 @@ namespace Microsoft.PowerBI.Commands.Workspaces
 
         public override void ExecuteCmdlet()
         {
-            var workspaceId = this.ParameterSet.Equals(IdParameterSetName) ? this.Id : this.Workspace.Id;
+            var workspaceId = (this.ParameterSet.Equals(UserEmailWithIdParameterSetName) || this.ParameterSet.Equals(PrincipalTypeWithIdParameterSetName)) ? this.Id : this.Workspace.Id;
+            bool usingPrincipalType = this.ParameterSet.Equals(PrincipalTypeWithIdParameterSetName) || this.ParameterSet.Equals(PrincipalTypeWithWorkspaceParameterSetName);
 
             WorkspaceUser userAccessRight;
-
-            if (this.PrincipalType.HasValue)
+            if (usingPrincipalType)
             {
-                userAccessRight = new WorkspaceUser { AccessRight = this.AccessRight.ToString(), Identifier = this.Identifier, PrincipalType = this.PrincipalType.ToString() };
+                userAccessRight = new WorkspaceUser { AccessRight = this.AccessRight.ToString(), Identifier = this.Identifier, PrincipalType = this.PrincipalType };
             }
             else
             {

--- a/src/Modules/Workspaces/Commands.Workspaces/AddPowerBIWorkspaceUser.cs
+++ b/src/Modules/Workspaces/Commands.Workspaces/AddPowerBIWorkspaceUser.cs
@@ -35,13 +35,19 @@ namespace Microsoft.PowerBI.Commands.Workspaces
         [Alias("GroupId", "WorkspaceId")]
         public Guid Id { get; set; }
 
-        [Parameter(Mandatory = true)]
+        [Parameter(Mandatory = false)]
+        public string Identifier { get; set; }
+
+        [Parameter(Mandatory = false)]
         [Alias("UserEmailAddress")]
         public string UserPrincipalName { get; set; }
 
         [Parameter(Mandatory = true)]
         [Alias("UserAccessRight")]
         public WorkspaceUserAccessRight AccessRight { get; set; }
+
+        [Parameter(Mandatory = false)]
+        public WorkspaceUserPrincipalType? PrincipalType { get; set; }
 
         [Parameter(Mandatory = true, ParameterSetName = WorkspaceParameterSetName)]
         [Alias("Group")]
@@ -62,7 +68,17 @@ namespace Microsoft.PowerBI.Commands.Workspaces
         public override void ExecuteCmdlet()
         {
             var workspaceId = this.ParameterSet.Equals(IdParameterSetName) ? this.Id : this.Workspace.Id;
-            var userAccessRight = new WorkspaceUser { AccessRight = this.AccessRight.ToString(), UserPrincipalName = this.UserPrincipalName };
+
+            WorkspaceUser userAccessRight;
+
+            if (this.PrincipalType.HasValue)
+            {
+                userAccessRight = new WorkspaceUser { AccessRight = this.AccessRight.ToString(), Identifier = this.Identifier, PrincipalType = this.PrincipalType.ToString() };
+            }
+            else
+            {
+                userAccessRight = new WorkspaceUser { AccessRight = this.AccessRight.ToString(), UserPrincipalName = this.UserPrincipalName };
+            }
 
             using (var client = this.CreateClient())
             {

--- a/src/Modules/Workspaces/Commands.Workspaces/help/Add-PowerBIWorkspaceUser.md
+++ b/src/Modules/Workspaces/Commands.Workspaces/help/Add-PowerBIWorkspaceUser.md
@@ -28,7 +28,7 @@ Add-PowerBIWorkspaceUser [-Scope <PowerBIUserScope>] [-Identifier <String>] [-Us
 
 ## DESCRIPTION
 Grants permissions to a specified user to access a Power BI workspace using the provided inputs and scope specified.
-Before you run this command, make sure you log in using Connect-PowerBIServiceAccount. 
+Before you run this command, make sure you log in using Connect-PowerBIServiceAccount.
 
 ## EXAMPLES
 
@@ -71,7 +71,7 @@ Accept wildcard characters: False
 ```
 
 ### -Identifier
-{{Fill Identifier Description}}
+Identifier of the principal to add to the group. For Apps and Groups, this will be their object identifier (GUID). For users, this can be an email address.
 
 ```yaml
 Type: String
@@ -86,7 +86,7 @@ Accept wildcard characters: False
 ```
 
 ### -PrincipalType
-{{Fill PrincipalType Description}}
+The type of the principal to add to the group.
 
 ```yaml
 Type: WorkspaceUserPrincipalType

--- a/src/Modules/Workspaces/Commands.Workspaces/help/Add-PowerBIWorkspaceUser.md
+++ b/src/Modules/Workspaces/Commands.Workspaces/help/Add-PowerBIWorkspaceUser.md
@@ -14,14 +14,16 @@ Gives permissions to a specified user to access a Power BI workspace.
 
 ### Id (Default)
 ```
-Add-PowerBIWorkspaceUser [-Scope <PowerBIUserScope>] -Id <Guid> -UserPrincipalName <String>
- -AccessRight <WorkspaceUserAccessRight> [<CommonParameters>]
+Add-PowerBIWorkspaceUser [-Scope <PowerBIUserScope>] -Id <Guid> [-Identifier <String>]
+ [-UserPrincipalName <String>] -AccessRight <WorkspaceUserAccessRight>
+ [-PrincipalType <WorkspaceUserPrincipalType>] [<CommonParameters>]
 ```
 
 ### Workspace
 ```
-Add-PowerBIWorkspaceUser [-Scope <PowerBIUserScope>] -UserPrincipalName <String>
- -AccessRight <WorkspaceUserAccessRight> -Workspace <Workspace> [<CommonParameters>]
+Add-PowerBIWorkspaceUser [-Scope <PowerBIUserScope>] [-Identifier <String>] [-UserPrincipalName <String>]
+ -AccessRight <WorkspaceUserAccessRight> [-PrincipalType <WorkspaceUserPrincipalType>] -Workspace <Workspace>
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -68,6 +70,37 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
+### -Identifier
+{{Fill Identifier Description}}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PrincipalType
+{{Fill PrincipalType Description}}
+
+```yaml
+Type: WorkspaceUserPrincipalType
+Parameter Sets: (All)
+Aliases:
+Accepted values: App, Group, User
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Scope
 Indicates scope of the call. Individual operates against only workspaces assigned to the caller; Organization operates against all workspaces within a tenant (must be an administrator to initiate). Individual is the default.
 
@@ -92,7 +125,7 @@ Type: String
 Parameter Sets: (All)
 Aliases: UserEmailAddress
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/src/Modules/Workspaces/Commands.Workspaces/help/Add-PowerBIWorkspaceUser.md
+++ b/src/Modules/Workspaces/Commands.Workspaces/help/Add-PowerBIWorkspaceUser.md
@@ -12,18 +12,28 @@ Gives permissions to a specified user to access a Power BI workspace.
 
 ## SYNTAX
 
-### Id (Default)
+### UserEmailWithId (Default)
 ```
-Add-PowerBIWorkspaceUser [-Scope <PowerBIUserScope>] -Id <Guid> [-Identifier <String>]
- [-UserPrincipalName <String>] -AccessRight <WorkspaceUserAccessRight>
- [-PrincipalType <WorkspaceUserPrincipalType>] [<CommonParameters>]
+Add-PowerBIWorkspaceUser [-Scope <PowerBIUserScope>] -Id <Guid> -UserPrincipalName <String>
+ -AccessRight <WorkspaceUserAccessRight> [<CommonParameters>]
 ```
 
-### Workspace
+### PrincipalTypeWithId
 ```
-Add-PowerBIWorkspaceUser [-Scope <PowerBIUserScope>] [-Identifier <String>] [-UserPrincipalName <String>]
- -AccessRight <WorkspaceUserAccessRight> [-PrincipalType <WorkspaceUserPrincipalType>] -Workspace <Workspace>
- [<CommonParameters>]
+Add-PowerBIWorkspaceUser [-Scope <PowerBIUserScope>] -Id <Guid> -AccessRight <WorkspaceUserAccessRight>
+ -PrincipalType <WorkspaceUserPrincipalType> -Identifier <String> [<CommonParameters>]
+```
+
+### UserEmailWithWorkspace
+```
+Add-PowerBIWorkspaceUser [-Scope <PowerBIUserScope>] -UserPrincipalName <String>
+ -AccessRight <WorkspaceUserAccessRight> -Workspace <Workspace> [<CommonParameters>]
+```
+
+### PrincipalTypeWithWorkspace
+```
+Add-PowerBIWorkspaceUser [-Scope <PowerBIUserScope>] -AccessRight <WorkspaceUserAccessRight>
+ -Workspace <Workspace> -PrincipalType <WorkspaceUserPrincipalType> -Identifier <String> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -60,7 +70,7 @@ ID of the workspace the user should be added to.
 
 ```yaml
 Type: Guid
-Parameter Sets: Id
+Parameter Sets: UserEmailWithId, PrincipalTypeWithId
 Aliases: GroupId, WorkspaceId
 
 Required: True
@@ -75,10 +85,10 @@ Identifier of the principal to add to the group. For Apps and Groups, this will 
 
 ```yaml
 Type: String
-Parameter Sets: (All)
-Aliases:
+Parameter Sets: PrincipalTypeWithId, PrincipalTypeWithWorkspace
+Aliases: PrincipalId
 
-Required: False
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -90,11 +100,11 @@ The type of the principal to add to the group.
 
 ```yaml
 Type: WorkspaceUserPrincipalType
-Parameter Sets: (All)
+Parameter Sets: PrincipalTypeWithId, PrincipalTypeWithWorkspace
 Aliases:
 Accepted values: App, Group, User
 
-Required: False
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -122,10 +132,10 @@ User Principal Name (or UPN, commonly an email address) for the user whose permi
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: UserEmailWithId, UserEmailWithWorkspace
 Aliases: UserEmailAddress
 
-Required: False
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -137,7 +147,7 @@ The workspace entity to add the user to.
 
 ```yaml
 Type: Workspace
-Parameter Sets: Workspace
+Parameter Sets: UserEmailWithWorkspace, PrincipalTypeWithWorkspace
 Aliases: Group
 
 Required: True


### PR DESCRIPTION
This change allows users to add Apps and Groups to Power BI workspaces. It follows the specification of the ["Add Group User" REST API](https://docs.microsoft.com/en-us/rest/api/power-bi/groups/addgroupuser).