### PR TITLE
Reintroduce get activity events

### DIFF
--- a/examples/GetPowerBIActivityEvents.ps1
+++ b/examples/GetPowerBIActivityEvents.ps1
@@ -1,0 +1,95 @@
+﻿<#
+
+.Synopsis
+    Retrieves the audit activity events for a Power BI tenant. 
+.Description
+    Retrieves the audit activity events for a Power BI tenant with in a time window.
+    This script uses the MicrosoftPowerBIMgmt.Profile PowerShell module. if this module isn't installed it will be installed into your current user profile.
+.Parameter StartDateTime
+    Specifies the start of a timespan to retrieve audit activity events. It should be in UTC format and ISO 8601 compliant.
+    Both StartDateTime and EndDateTime should be within the same UTC day.
+.Parameter EndDateTime
+    Specifies the end of a timespan to retrieve audit activity events. It should be in UTC format and ISO 8601 compliant.
+    Both StartDateTime and EndDateTime should be within the same UTC day.
+.Parameter ActivityType
+    Filters the activity records based on this activity type.
+.Parameter User
+    Filters the activity records based on this user email.
+.Example
+    PS C:\> .\GetPowerBIActivityEvents.ps1 -StartDateTime 2019-09-12T00:00:00 -EndDateTime 2019-09-12T10:00:00 -ActivityType viewreport -User admin@contoso.com
+
+#>
+
+[CmdletBinding()]
+param
+(
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string] $StartDateTime,
+
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string] $EndDateTime,
+
+    [string] $ActivityType,
+
+    [string] $User
+)
+
+#region Helper Functions 
+
+function Assert-ModuleExists([string]$ModuleName) {
+    $module = Get-Module $ModuleName -ListAvailable -ErrorAction SilentlyContinue
+    if (!$module) {
+        Write-Host "Installing module $ModuleName ..."
+        Install-Module -Name $ModuleName -Force -Scope CurrentUser
+        Write-Host "Module installed"
+    }
+    elseif ($module.Version -ne '1.0.0' -and $module.Version -le '1.0.410') {
+        Write-Host "Updating module $ModuleName ..."
+        Update-Module -Name $ModuleName -Force -ErrorAction Stop
+        Write-Host "Module updated"
+    }
+}
+
+Assert-ModuleExists -ModuleName "MicrosoftPowerBIMgmt.Profile"
+Login-PowerBI
+
+$result = @() # empty array to dump activity events into.
+
+$UriPrefix = "admin/activityevents?"
+$OriginalUrl = [string]::Format("{0}startDateTime='{1}'&endDateTime='{2}'",$UriPrefix,$StartDateTime,$EndDateTime)
+
+if (!([string]::IsNullOrEmpty($ActivityType)) -and ([string]::IsNullOrEmpty($User))) {
+    $OriginalUrl = [string]::Format("{0}&`$filter=Activity eq '{1}'",$OriginalUrl,$ActivityType)
+}
+elseif (([string]::IsNullOrEmpty($ActivityType)) -and !([string]::IsNullOrEmpty($User))) {
+    $OriginalUrl = [string]::Format("{0}&`$filter=UserId eq '{1}'",$OriginalUrl,$User)
+}
+elseif (!([string]::IsNullOrEmpty($ActivityType)) -and !([string]::IsNullOrEmpty($User))) {
+    $OriginalUrl = [string]::Format("{0}&`$filter=Activity eq '{1}' and UserId eq '{2}'",$OriginalUrl,$ActivityType,$User)
+}
+
+$activityEvents = (Invoke-PowerBIRestMethod -Url $OriginalUrl -Method Get) | ConvertFrom-Json
+$result = $result + $activityEvents.activityEventEntities
+$continuationUri = $activityEvents.continuationUri
+$continuationToken = $activityEvents.continuationToken
+
+# Checking on both continuationUri and continuationToken since the continuationUri changes are still flighting across rings at the time of this script's check in.
+while ($continuationUri -or $continuationToken) {
+    $FullUri = [string]::Empty
+    if (![string]::IsNullOrEmpty($continuationUri)) {
+        $UriAndQuerySplit = $continuationUri -split "\?"
+        $FullUri = [string]::Format("{0}{1}",$UriPrefix,$UriAndQuerySplit[1])    
+    }
+    elseif (![string]::IsNullOrEmpty($continuationToken)) {
+        $FullUri = [string]::Format("{0}&continuationToken='{1}'",$OriginalUrl,$continuationToken)
+    }
+    
+    $activityEvents = (Invoke-PowerBIRestMethod -Url $FullUri -Method Get) | ConvertFrom-Json
+    $result = $result + $activityEvents.activityEventEntities
+    $continuationUri = $activityEvents.continuationUri
+    $continuationToken = $activityEvents.continuationToken
+}
+
+$result

--- a/src/Modules/Admin/Commands.Admin.Test/GetPowerBIActivityEventTests.cs
+++ b/src/Modules/Admin/Commands.Admin.Test/GetPowerBIActivityEventTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.PowerBI.Commands.Admin.Test
         private static string StartDateTime = "2019-08-15T20:00:00Z";
         private static string EndDateTime = "2019-08-15T22:00:00Z";
 
-        // [TestMethod] -- disabling this test until we bring back the cmdlet live again.
+        // [TestMethod] -- disabling this test until we bring back the cmdlet again.
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
         public void EndToEndGetPowerBIActivityEvents()

--- a/src/Modules/Admin/Commands.Admin.Test/GetPowerBIActivityEventTests.cs
+++ b/src/Modules/Admin/Commands.Admin.Test/GetPowerBIActivityEventTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.PowerBI.Commands.Admin.Test
         private static string StartDateTime = "2019-08-15T20:00:00Z";
         private static string EndDateTime = "2019-08-15T22:00:00Z";
 
-        // [TestMethod] -- disabling this test until we bring back the cmdlet again.
+        [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
         public void EndToEndGetPowerBIActivityEvents()

--- a/src/Modules/Admin/Commands.Admin/MicrosoftPowerBIMgmt.Admin.psd1
+++ b/src/Modules/Admin/Commands.Admin/MicrosoftPowerBIMgmt.Admin.psd1
@@ -71,13 +71,13 @@ FormatsToProcess = @('Microsoft.PowerBI.Commands.Admin.format.ps1xml')
 FunctionsToExport = '*'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
-CmdletsToExport = 'Add-PowerBIEncryptionKey', 'Get-PowerBIEncryptionKey', 'Get-PowerBIWorkspaceEncryptionStatus', 'Switch-PowerBIEncryptionKey', 'Set-PowerBICapacityEncryptionKey'
+CmdletsToExport = 'Add-PowerBIEncryptionKey', 'Get-PowerBIEncryptionKey', 'Get-PowerBIWorkspaceEncryptionStatus', 'Switch-PowerBIEncryptionKey', 'Set-PowerBICapacityEncryptionKey', 'Get-PowerBIActivityEvent'
 
 # Variables to export from this module
 VariablesToExport = '*'
 
 # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-AliasesToExport = 'Rotate-PowerBIEncryptionKey'
+AliasesToExport = 'Rotate-PowerBIEncryptionKey', 'Get-PowerBIActivityEvents'
 
 # DSC resources to export from this module
 # DscResourcesToExport = @()

--- a/src/Modules/Admin/Commands.Admin/help/Get-PowerBIActivityEvent.md
+++ b/src/Modules/Admin/Commands.Admin/help/Get-PowerBIActivityEvent.md
@@ -1,0 +1,132 @@
+---
+external help file: Microsoft.PowerBI.Commands.Admin.dll-Help.xml
+Module Name: MicrosoftPowerBIMgmt.Admin
+online version: https://docs.microsoft.com/en-us/powershell/module/microsoftpowerbimgmt.admin/get-powerbiactivityevent?view=powerbi-ps
+schema: 2.0.0
+---
+
+# Get-PowerBIActivityEvent
+
+## SYNOPSIS
+Retrieves the audit activity events for a Power BI tenant.
+
+## SYNTAX
+
+```
+Get-PowerBIActivityEvent -StartDateTime <String> -EndDateTime <String> [-ActivityType <String>]
+ [-User <String>] [-ResultType <OutputType>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Retrieves the audit activity events for the calling user's tenant.
+Before you run this command, make sure you log in using Connect-PowerBIServiceAccount.
+This cmdlet requires the calling user to be a tenant administrator of the Power BI service.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Get-PowerBIActivityEvent -StartDateTime 2019-08-10T14:35:20 -EndDateTime 2019-08-10T18:25:50
+```
+
+Retrieves Power BI activity events between 08-10-19 14:35:20 UTC and 08-10-2019 18:25:50 UTC
+
+### Example 2
+```powershell
+PS C:\> Get-PowerBIActivityEvents -StartDateTime 2019-08-10T14:35:20 -EndDateTime 2019-08-10T18:25:50 -ActivityType viewreport -User admin@contoso.com -ResultType JsonObject
+```
+
+Retrieves Power BI activity events between 08-10-19 14:35:20 UTC and 08-10-2019 18:25:50 UTC with the activity type of viewreport for user admin@contoso.com. Output will be JSON objects.
+
+## PARAMETERS
+
+### -ActivityType
+Filters the activity records based on this activity type.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EndDateTime
+Specifies the end of a timespan to retrieve audit activity events. It should be in UTC format and ISO 8601 compliant. Both StartDateTime and EndDateTime should be within the same UTC day.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ResultType
+Specifies the type of result that is returned by the cmdlet.
+
+```yaml
+Type: OutputType
+Parameter Sets: (All)
+Aliases:
+Accepted values: JsonString, JsonObject
+
+Required: False
+Position: Named
+Default value: JsonString
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -StartDateTime
+Specifies the start of a timespan to retrieve audit activity events. It should be in UTC format and ISO 8601 compliant. Both StartDateTime and EndDateTime should be within the same UTC day.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -User
+Filters the activity records based on this user email.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Collections.Generic.IList`1[[System.Object, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]
+
+## NOTES
+
+## RELATED LINKS

--- a/src/Modules/Admin/Commands.Admin/help/Get-PowerBIActivityEvent.md
+++ b/src/Modules/Admin/Commands.Admin/help/Get-PowerBIActivityEvent.md
@@ -33,7 +33,7 @@ Retrieves Power BI activity events between 08-10-19 14:35:20 UTC and 08-10-2019 
 
 ### Example 2
 ```powershell
-PS C:\> Get-PowerBIActivityEvents -StartDateTime 2019-08-10T14:35:20 -EndDateTime 2019-08-10T18:25:50 -ActivityType viewreport -User admin@contoso.com -ResultType JsonObject
+PS C:\> Get-PowerBIActivityEvent -StartDateTime 2019-08-10T14:35:20 -EndDateTime 2019-08-10T18:25:50 -ActivityType viewreport -User admin@contoso.com -ResultType JsonObject
 ```
 
 Retrieves Power BI activity events between 08-10-19 14:35:20 UTC and 08-10-2019 18:25:50 UTC with the activity type of viewreport for user admin@contoso.com. Output will be JSON objects.

--- a/src/Modules/Admin/Commands.Admin/help/MicrosoftPowerBIMgmt.Admin.md
+++ b/src/Modules/Admin/Commands.Admin/help/MicrosoftPowerBIMgmt.Admin.md
@@ -14,6 +14,9 @@ PowerShell cmdlets for performing administrative duties across the Power BI serv
 ### [Add-PowerBIEncryptionKey](Add-PowerBIEncryptionKey.md)
 Adds an encryption key for Power BI workspaces assigned to a capacity.
 
+### [Get-PowerBIActivityEvent](Get-PowerBIActivityEvent.md)
+Retrieves the audit activity events for a Power BI tenant.
+
 ### [Get-PowerBIEncryptionKey](Get-PowerBIEncryptionKey.md)
 Retrieves the encryption key for the tenant.
 


### PR DESCRIPTION
Since the Admin API for activity events is checked in. We should be re-introducing the Get-PowerBIActivityEvents cmdlet.