### PR TITLE
Add timeout parameter to invoke powerbi rest method

### DIFF
--- a/src/Modules/Profile/Commands.Profile.Test/InvokePowerBIRestMethodTests.cs
+++ b/src/Modules/Profile/Commands.Profile.Test/InvokePowerBIRestMethodTests.cs
@@ -3,10 +3,12 @@
  * Licensed under the MIT License.
  */
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
 using System.Net.Http;
+using System.Threading;
 using Microsoft.PowerBI.Commands.Common.Test;
 using Microsoft.PowerBI.Common.Abstractions.Interfaces;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -55,7 +57,7 @@ namespace Microsoft.PowerBI.Commands.Profile.Test
                         { testHeaderName, testHeaderValue }
                     }
                 };
-                
+
                 // Act
                 mock.InvokePopulateClient(accessToken, client);
 
@@ -65,6 +67,47 @@ namespace Microsoft.PowerBI.Commands.Profile.Test
                 Assert.IsNotNull(headerValues);
                 Assert.AreEqual(1, headerValues.Count());
                 Assert.AreEqual(testHeaderValue, headerValues.First());
+            }
+        }
+
+        [TestMethod]
+        public void InvokePowerBIRestMethod_PositiveTimeout()
+        {
+            // Arrange
+            var initFactory = new TestPowerBICmdletNoClientInitFactory(true);
+            var testAuthenticator = initFactory.Authenticator;
+            var accessToken = testAuthenticator.Authenticate(profile: null, logger: null, settings: null, queryParameters: null);
+            using (var client = new HttpClient())
+            {
+                var mock = new MockInvokePowerBIRestMethodCmdlet(initFactory)
+                {
+                    TimeoutSec = 100
+                };
+
+                // Act
+                mock.InvokePopulateClient(accessToken, client);
+
+                // Assert
+                Assert.AreEqual(client.Timeout, TimeSpan.FromSeconds(100));
+            }
+        }
+
+        [TestMethod]
+        public void InvokePowerBIRestMethod_DefaultTimeout()
+        {
+            // Arrange
+            var initFactory = new TestPowerBICmdletNoClientInitFactory(true);
+            var testAuthenticator = initFactory.Authenticator;
+            var accessToken = testAuthenticator.Authenticate(profile: null, logger: null, settings: null, queryParameters: null);
+            using (var client = new HttpClient())
+            {
+                var mock = new MockInvokePowerBIRestMethodCmdlet(initFactory);
+
+                // Act
+                mock.InvokePopulateClient(accessToken, client);
+
+                // Assert
+                Assert.AreEqual(client.Timeout, Timeout.InfiniteTimeSpan);
             }
         }
 

--- a/src/Modules/Profile/Commands.Profile.Test/InvokePowerBIRestMethodTests.cs
+++ b/src/Modules/Profile/Commands.Profile.Test/InvokePowerBIRestMethodTests.cs
@@ -81,14 +81,14 @@ namespace Microsoft.PowerBI.Commands.Profile.Test
             {
                 var mock = new MockInvokePowerBIRestMethodCmdlet(initFactory)
                 {
-                    TimeoutSec = 100
+                    TimeoutSec = 200
                 };
 
                 // Act
                 mock.InvokePopulateClient(accessToken, client);
 
                 // Assert
-                Assert.AreEqual(client.Timeout, TimeSpan.FromSeconds(100));
+                Assert.AreEqual(client.Timeout, TimeSpan.FromSeconds(200));
             }
         }
 
@@ -107,7 +107,7 @@ namespace Microsoft.PowerBI.Commands.Profile.Test
                 mock.InvokePopulateClient(accessToken, client);
 
                 // Assert
-                Assert.AreEqual(client.Timeout, Timeout.InfiniteTimeSpan);
+                Assert.AreEqual(client.Timeout, TimeSpan.FromSeconds(100)); // default http client timeout
             }
         }
 

--- a/src/Modules/Profile/Commands.Profile.Test/InvokePowerBIRestMethodTests.cs
+++ b/src/Modules/Profile/Commands.Profile.Test/InvokePowerBIRestMethodTests.cs
@@ -111,6 +111,28 @@ namespace Microsoft.PowerBI.Commands.Profile.Test
             }
         }
 
+        [TestMethod]
+        public void InvokePowerBIRestMethod_ZeroTimeout()
+        {
+            // Arrange
+            var initFactory = new TestPowerBICmdletNoClientInitFactory(true);
+            var testAuthenticator = initFactory.Authenticator;
+            var accessToken = testAuthenticator.Authenticate(profile: null, logger: null, settings: null, queryParameters: null);
+            using (var client = new HttpClient())
+            {
+                var mock = new MockInvokePowerBIRestMethodCmdlet(initFactory)
+                {
+                    TimeoutSec = 0
+                };
+
+                // Act
+                mock.InvokePopulateClient(accessToken, client);
+
+                // Assert
+                Assert.AreEqual(client.Timeout, Timeout.InfiniteTimeSpan); // default http client timeout
+            }
+        }
+
         private class MockInvokePowerBIRestMethodCmdlet : InvokePowerBIRestMethod
         {
             public MockInvokePowerBIRestMethodCmdlet() : base() { }

--- a/src/Modules/Profile/Commands.Profile/InvokePowerBIRestMethod.cs
+++ b/src/Modules/Profile/Commands.Profile/InvokePowerBIRestMethod.cs
@@ -60,7 +60,7 @@ namespace Microsoft.PowerBI.Commands.Profile
         public Hashtable Headers { get; set; }
 
         [Parameter(Mandatory = false)]
-        public int TimeoutSec { get; set; } = 0;
+        public int TimeoutSec { get; set; }
         #endregion
 
         public override void ExecuteCmdlet()

--- a/src/Modules/Profile/Commands.Profile/InvokePowerBIRestMethod.cs
+++ b/src/Modules/Profile/Commands.Profile/InvokePowerBIRestMethod.cs
@@ -60,7 +60,7 @@ namespace Microsoft.PowerBI.Commands.Profile
         public Hashtable Headers { get; set; }
 
         [Parameter(Mandatory = false)]
-        public int TimeoutSec { get; set; }
+        public int? TimeoutSec { get; set; }
         #endregion
 
         public override void ExecuteCmdlet()
@@ -219,13 +219,20 @@ namespace Microsoft.PowerBI.Commands.Profile
             client.DefaultRequestHeaders.UserAgent.Clear();
             client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("MicrosoftPowerBIMgmt-InvokeRest", PowerBICmdlet.CmdletVersion));
 
-            if (this.TimeoutSec < 0)
+            if (this.TimeoutSec != null)
             {
-                this.Logger.ThrowTerminatingError($"{nameof(this.TimeoutSec)} value cannot be negative.");
-            }
-            else if (this.TimeoutSec > 0)
-            {
-                client.Timeout = TimeSpan.FromSeconds(this.TimeoutSec);
+                if (this.TimeoutSec < 0)
+                {
+                    this.Logger.ThrowTerminatingError($"{nameof(this.TimeoutSec)} value cannot be negative.");
+                }
+                else if (this.TimeoutSec > 0)
+                {
+                    client.Timeout = TimeSpan.FromSeconds(Convert.ToDouble(this.TimeoutSec));
+                }
+                else
+                {
+                    client.Timeout = Timeout.InfiniteTimeSpan;
+                }
             }
 
             if (this.Headers != null)

--- a/src/Modules/Profile/Commands.Profile/InvokePowerBIRestMethod.cs
+++ b/src/Modules/Profile/Commands.Profile/InvokePowerBIRestMethod.cs
@@ -227,10 +227,6 @@ namespace Microsoft.PowerBI.Commands.Profile
             {
                 client.Timeout = TimeSpan.FromSeconds(this.TimeoutSec);
             }
-            else
-            {
-                client.Timeout = Timeout.InfiniteTimeSpan;
-            }
 
             if (this.Headers != null)
             {

--- a/src/Modules/Profile/Commands.Profile/InvokePowerBIRestMethod.cs
+++ b/src/Modules/Profile/Commands.Profile/InvokePowerBIRestMethod.cs
@@ -10,6 +10,7 @@ using System.Management.Automation;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.PowerBI.Commands.Common;
 using Microsoft.PowerBI.Common.Abstractions.Interfaces;
@@ -57,6 +58,9 @@ namespace Microsoft.PowerBI.Commands.Profile
 
         [Parameter(Mandatory = false)]
         public Hashtable Headers { get; set; }
+
+        [Parameter(Mandatory = false)]
+        public int TimeoutSec { get; set; } = 0;
         #endregion
 
         public override void ExecuteCmdlet()
@@ -214,6 +218,19 @@ namespace Microsoft.PowerBI.Commands.Profile
             client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token.AccessToken);
             client.DefaultRequestHeaders.UserAgent.Clear();
             client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("MicrosoftPowerBIMgmt-InvokeRest", PowerBICmdlet.CmdletVersion));
+
+            if (this.TimeoutSec < 0)
+            {
+                this.Logger.ThrowTerminatingError($"{nameof(this.TimeoutSec)} value cannot be negative.");
+            }
+            else if (this.TimeoutSec > 0)
+            {
+                client.Timeout = TimeSpan.FromSeconds(this.TimeoutSec);
+            }
+            else
+            {
+                client.Timeout = Timeout.InfiniteTimeSpan;
+            }
 
             if (this.Headers != null)
             {

--- a/src/Modules/Profile/Commands.Profile/help/Invoke-PowerBIRestMethod.md
+++ b/src/Modules/Profile/Commands.Profile/help/Invoke-PowerBIRestMethod.md
@@ -126,7 +126,7 @@ Accept wildcard characters: False
 ```
 
 ### -TimeoutSec
-Specifies how long the request can be pending before it times out. Enter a value in seconds. The default value, 0, specifies an indefinite time-out.
+Specifies how long the request can be pending before it times out. Enter a value in seconds.
 
 ```yaml
 Type: Int32
@@ -135,7 +135,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: 0
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/src/Modules/Profile/Commands.Profile/help/Invoke-PowerBIRestMethod.md
+++ b/src/Modules/Profile/Commands.Profile/help/Invoke-PowerBIRestMethod.md
@@ -126,7 +126,7 @@ Accept wildcard characters: False
 ```
 
 ### -TimeoutSec
-Specifies how long the request can be pending before it times out. Enter a value in seconds.
+Specifies how long the request can be pending before it times out. Enter a value in seconds. Entering a value of 0 specifies an indefinite time-out. 
 
 ```yaml
 Type: Int32
@@ -135,7 +135,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: 100
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/src/Modules/Profile/Commands.Profile/help/Invoke-PowerBIRestMethod.md
+++ b/src/Modules/Profile/Commands.Profile/help/Invoke-PowerBIRestMethod.md
@@ -14,8 +14,8 @@ Executes a REST call to the Power BI service, with the specified URL and body.
 
 ```
 Invoke-PowerBIRestMethod -Url <String> -Method <PowerBIWebRequestMethod> [-Body <String>] [-OutFile <String>]
- [-ContentType <String>] [-Headers <Hashtable>] [-Organization <String>] [-Version <String>]
- [<CommonParameters>]
+ [-ContentType <String>] [-Headers <Hashtable>] [-TimeoutSec <Int32>] [-Organization <String>]
+ [-Version <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -121,6 +121,21 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TimeoutSec
+Specifies how long the request can be pending before it times out. Enter a value in seconds. The default value, 0, specifies an indefinite time-out.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
- In the event that the server is taking longer than the default client time out (100 seconds), client will prematurely end the request before the server has finished processing. 
- Allow consumers of this cmdlet to optionally specify a client timeout value.