### PR TITLE
New Report fix when no Name parameter given

### DIFF
--- a/src/Modules/Reports/Commands.Reports.Test/NewPowerBIReportTests.cs
+++ b/src/Modules/Reports/Commands.Reports.Test/NewPowerBIReportTests.cs
@@ -70,6 +70,29 @@ namespace Commands.Reports.Test
         }
 
         [TestMethod]
+        [TestCategory("Interactive")]
+        [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        public void EndToEndNewReportWorkspaceWithoutName()
+        {
+            using (var ps = PowerShell.Create())
+            {
+                // Arrange
+                ProfileTestUtilities.ConnectToPowerBI(ps, PowerBIEnvironmentType.Public);
+                var workspace = WorkspacesTestUtilities.GetFirstWorkspace(ps, PowerBIUserScope.Individual);
+
+                ps.AddCommand(Cmdlet)
+                    .AddParameter(nameof(NewPowerBIReport.Path), "./testreport.pbix")
+                    .AddParameter(nameof(NewPowerBIReport.WorkspaceId), workspace.Id.ToString());
+
+                // Act
+                var reportId = ps.Invoke();
+
+                // Assert
+                TestUtilities.AssertNoCmdletErrors(ps);
+            }
+        }
+
+        [TestMethod]
         [ExpectedException(typeof(CmdletInvocationException))]
         public void EndToEndNewReportsWithoutLogin()
         {

--- a/src/Modules/Reports/Commands.Reports/NewPowerBIReport.cs
+++ b/src/Modules/Reports/Commands.Reports/NewPowerBIReport.cs
@@ -71,7 +71,7 @@ namespace Microsoft.PowerBI.Commands.Reports
             if (this.Name == null)
             {
                 var report = new System.IO.FileInfo(this.ResolveFilePath(this.Path, true));
-                this.Name = report.Name.Replace(".pbix", "");
+                this.Name = report.Name;
             }
 
             using (var client = this.CreateClient())


### PR DESCRIPTION
When no name is given, we get the name from path and name is getting truncated. 