### PR TITLE
Added remove dataset command

### DIFF
--- a/src/Common/Common.Api/Datasets/DatasetsClient.cs
+++ b/src/Common/Common.Api/Datasets/DatasetsClient.cs
@@ -60,6 +60,23 @@ namespace Microsoft.PowerBI.Common.Api.Datasets
             }
         }
 
+        public object DeleteDataset(Guid datasetId, Guid? workspaceId = default)
+        {
+            if (workspaceId.HasValue && workspaceId.Value != default)
+            {
+                return this.Client.Datasets.DeleteDatasetByIdInGroup(groupId: workspaceId.Value.ToString(), datasetKey: datasetId.ToString());
+            }
+            else
+            {
+                return this.Client.Datasets.DeleteDatasetById(datasetKey: datasetId.ToString());
+            }
+        }
+
+        public object DeleteDataset(Guid datasetId)
+        {
+            return this.Client.Datasets.DeleteDatasetById(datasetKey: datasetId.ToString());
+        }
+
         public IEnumerable<Datasource> GetDatasources(Guid datasetId, Guid? workspaceId = default)
         {
             var result = workspaceId.HasValue && workspaceId.Value != default ?

--- a/src/Common/Common.Api/Datasets/IDatasetsClient.cs
+++ b/src/Common/Common.Api/Datasets/IDatasetsClient.cs
@@ -22,6 +22,9 @@ namespace Microsoft.PowerBI.Common.Api.Datasets
 
         void PatchDataset(Guid datasetId, PatchDatasetRequest patchDatasetRequest, Guid? workspaceId = default);
 
+        object DeleteDataset(Guid datasetId);
+        object DeleteDataset(Guid datasetId, Guid? workspaceId = default);
+
         IEnumerable<Datasource> GetDatasources(Guid datasetId, Guid? workspaceId = default);
         IEnumerable<Datasource> GetDatasourcesAsAdmin(Guid datasetId);
 

--- a/src/Modules/Data/Commands.Data.Test/RemovePowerBIDatasetTests.cs
+++ b/src/Modules/Data/Commands.Data.Test/RemovePowerBIDatasetTests.cs
@@ -1,0 +1,66 @@
+﻿/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using Microsoft.PowerBI.Commands.Common.Test;
+using Microsoft.PowerBI.Commands.Datasets;
+using Microsoft.PowerBI.Commands.Profile.Test;
+using Microsoft.PowerBI.Common.Abstractions;
+using Microsoft.PowerBI.Common.Api;
+using Microsoft.PowerBI.Common.Api.Datasets;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Microsoft.PowerBI.Commands.Data.Test
+{
+    [TestClass]
+    public class RemovePowerBIDatasetTests
+    {
+        [TestMethod]
+        [TestCategory("Interactive")]
+        [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        public void EndToEndRemovePowerBIDataset()
+        {
+            using (var ps = System.Management.Automation.PowerShell.Create())
+            {
+                ProfileTestUtilities.ConnectToPowerBI(ps, PowerBIEnvironmentType.Public); // If login is needed
+                ps.AddCommand(new CmdletInfo($"{RemovePowerBIDataset.CmdletVerb}-{RemovePowerBIDataset.CmdletName}", typeof(RemovePowerBIDataset)));
+                ps.AddParameter("Id", "fce8abb5-192b-4be2-b75e-b43bb93d8943");
+                ps.AddParameter("WorkspaceId", "kjsdfjs;sf");
+                var result = ps.Invoke();
+
+                // Add asserts to verify
+
+                TestUtilities.AssertNoCmdletErrors(ps);
+            }
+        }
+
+        [TestMethod]
+        public void RemovePowerBIDatasetTest()
+        {
+            // Arrange 
+            var datasetID = Guid.NewGuid();
+            object expectedResponse = null;
+            var client = new Mock<IPowerBIApiClient>();
+            client.Setup(x => x.Datasets
+                .DeleteDataset(datasetID))
+                .Returns(expectedResponse);
+            var initFactory = new TestPowerBICmdletInitFactory(client.Object);
+            var cmdlet = new RemovePowerBIDataset(initFactory)
+            {
+                Id = datasetID
+            };
+
+            // Act
+            cmdlet.InvokePowerBICmdlet();
+
+            // Assert
+            TestUtilities.AssertExpectedUnitTestResults(expectedResponse, client, initFactory);
+        }
+    }
+}

--- a/src/Modules/Data/Commands.Data/MicrosoftPowerBIMgmt.Data.psd1
+++ b/src/Modules/Data/Commands.Data/MicrosoftPowerBIMgmt.Data.psd1
@@ -71,7 +71,7 @@ FormatsToProcess = @('Microsoft.PowerBI.Commands.Data.format.ps1xml')
 FunctionsToExport = '*'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
-CmdletsToExport = 'Add-PowerBIDataset','Set-PowerBITable','New-PowerBIDataset','New-PowerBITable','New-PowerBIColumn','Get-PowerBIDataset','Get-PowerBIDatasource','Get-PowerBITable','Add-PowerBIRow','Remove-PowerBIRow','Set-PowerBIDataset', 'Get-PowerBIDataflow','Export-PowerBIDataflow','Get-PowerBIDataflowDatasource'
+CmdletsToExport = 'Add-PowerBIDataset','Set-PowerBITable','New-PowerBIDataset','New-PowerBITable','New-PowerBIColumn','Get-PowerBIDataset','Get-PowerBIDatasource','Get-PowerBITable','Add-PowerBIRow','Remove-PowerBIRow','Set-PowerBIDataset','Remove-PowerBIDataset', 'Get-PowerBIDataflow','Export-PowerBIDataflow','Get-PowerBIDataflowDatasource'
 
 # Variables to export from this module
 VariablesToExport = '*'

--- a/src/Modules/Data/Commands.Data/RemovePowerBIDataset.cs
+++ b/src/Modules/Data/Commands.Data/RemovePowerBIDataset.cs
@@ -1,0 +1,72 @@
+﻿/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+using System;
+using System.Management.Automation;
+using Microsoft.PowerBI.Common.Api.Workspaces;
+using Microsoft.PowerBI.Common.Client;
+
+namespace Microsoft.PowerBI.Commands.Datasets
+{
+    [Cmdlet(CmdletVerb, CmdletName, DefaultParameterSetName = MyWorkspaceParameterSetName)]
+    public class RemovePowerBIDataset : PowerBIClientCmdlet
+    {
+        public const string CmdletName = "PowerBIDataset";
+        public const string CmdletVerb = VerbsCommon.Remove;
+
+        #region ParameterSets
+
+        private const string MyWorkspaceParameterSetName = "MyWorkspace";
+        private const string WorkspaceIdParameterSetName = "WorkspaceId";
+        private const string WorkspaceParameterSetName = "Workspace";
+
+        #endregion
+
+        #region ParameterSets
+
+        [Parameter(Mandatory = true)]
+        [Alias("DatasetId")]
+        public Guid Id { get; set; }
+
+        [Parameter(Mandatory = true, ParameterSetName = WorkspaceIdParameterSetName)]
+        [Alias("GroupId")]
+        public Guid WorkspaceId { get; set; }
+
+        [Parameter(Mandatory = true, ParameterSetName = WorkspaceParameterSetName)]
+        [Alias("Group")]
+        public Workspace Workspace { get; set; }
+
+        #endregion
+
+        #region Constructors
+        public RemovePowerBIDataset() : base() { }
+
+        public RemovePowerBIDataset(IPowerBIClientCmdletInitFactory init) : base(init) { }
+        #endregion
+
+        public override void ExecuteCmdlet()
+        {
+            if (this.Workspace != default)
+            {
+                this.WorkspaceId = this.Workspace.Id;
+            }
+
+            using (var client = this.CreateClient())
+            {
+                object result = null;
+                if (this.WorkspaceId != default)
+                {
+                    result = client.Datasets.DeleteDataset(this.WorkspaceId, this.Id);
+                }
+                else
+                {
+                    result = client.Datasets.DeleteDataset(this.Id);
+                }
+
+                this.Logger.WriteObject(result, true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
I added a command to remove a dataset. If this is fine, i'll add some for workspaces, gateway datasources too, since I need these to cleanup a large environment.
I used the command to remove a report as reference, but unfortunately I wasn't able to run all tests.
Then the script `\scripts\GetNetstandardAssembly.ps1` failed with exit code 1. Can you please check it on your develop environment or the CI pipeline?

Thank you!