### PR TITLE
[ConnectPowerBIServiceAccount ] Support for Tenant parameter for User

### DIFF
--- a/src/Modules/Profile/Commands.Profile.Test/ConnectPowerBIServiceAccountTests.cs
+++ b/src/Modules/Profile/Commands.Profile.Test/ConnectPowerBIServiceAccountTests.cs
@@ -114,6 +114,38 @@ namespace Microsoft.PowerBI.Commands.Profile.Test
         }
 
         [TestMethod]
+        [TestCategory("Interactive")]
+        [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        public void ConnectPowerBIServiceAccountServiceWithTenantId_UserParameterSet()
+        {
+            using (var ps = System.Management.Automation.PowerShell.Create())
+            {
+                // Arrange
+                var environment = PowerBIEnvironmentType.OneBox;
+                var tenant = "039db662-19f0-4ca7-869a-3238540f1dd0";
+
+                ps.AddCommand(ProfileTestUtilities.ConnectPowerBIServiceAccountCmdletInfo)
+                    .AddParameter(nameof(ConnectPowerBIServiceAccount.Environment), environment)
+                    .AddParameter(nameof(ConnectPowerBIServiceAccount.Tenant), tenant);
+
+                // Act
+                var results = ps.Invoke();
+
+                // Assert
+                TestUtilities.AssertNoCmdletErrors(ps);
+                Assert.IsTrue(results.Count == 1);
+                Assert.IsTrue(results[0].BaseObject is PowerBIProfile);
+                var profile = results[0].BaseObject as PowerBIProfile;
+                Assert.AreEqual(tenant, profile.TenantId);
+
+                // Disconnect
+                ps.Commands.Clear();
+                ps.AddCommand(ProfileTestUtilities.DisconnectPowerBIServiceAccountCmdletInfo);
+                ps.Invoke();
+            }
+        }
+
+        [TestMethod]
         [ExpectedException(typeof(Exception))]
         public void ConnectPowerBIServiceAccountDiscoveryUrl_NullCustomEnvironment()
         {

--- a/src/Modules/Profile/Commands.Profile.Test/ConnectPowerBIServiceAccountTests.cs
+++ b/src/Modules/Profile/Commands.Profile.Test/ConnectPowerBIServiceAccountTests.cs
@@ -90,6 +90,38 @@ namespace Microsoft.PowerBI.Commands.Profile.Test
         }
 
         [TestMethod]
+        [TestCategory("Interactive")]
+        [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        public void ConnectPowerBIServiceAccountServiceWithTenantId_UserParameterSet()
+        {
+            using (var ps = System.Management.Automation.PowerShell.Create())
+            {
+                // Arrange
+                var environment = PowerBIEnvironmentType.OneBox;
+                var tenant = "039db662-19f0-4ca7-869a-3238540f1dd0"; // Onebox tenant for ComputeCdsa
+
+                ps.AddCommand(ProfileTestUtilities.ConnectPowerBIServiceAccountCmdletInfo)
+                    .AddParameter(nameof(ConnectPowerBIServiceAccount.Environment), environment)
+                    .AddParameter(nameof(ConnectPowerBIServiceAccount.Tenant), tenant);
+
+                // Act
+                var results = ps.Invoke();
+
+                // Assert
+                TestUtilities.AssertNoCmdletErrors(ps);
+                Assert.IsTrue(results.Count == 1);
+                Assert.IsTrue(results[0].BaseObject is PowerBIProfile);
+                var profile = results[0].BaseObject as PowerBIProfile;
+                Assert.AreEqual(tenant, profile.TenantId);
+
+                // Disconnect
+                ps.Commands.Clear();
+                ps.AddCommand(ProfileTestUtilities.DisconnectPowerBIServiceAccountCmdletInfo);
+                ps.Invoke();
+            }
+        }
+
+        [TestMethod]
         public void ConnectPowerBIServiceAccountServiceWithTenantId_PrincipalParameterSet()
         {
             // Arrange
@@ -111,38 +143,6 @@ namespace Microsoft.PowerBI.Commands.Profile.Test
             Assert.IsNotNull(profile);
             Assert.IsTrue(profile.Environment.AzureADAuthority.Contains(testTenantName));
             initFactory.AssertExpectedUnitTestResults(new[] { profile });
-        }
-
-        [TestMethod]
-        [TestCategory("Interactive")]
-        [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
-        public void ConnectPowerBIServiceAccountServiceWithTenantId_UserParameterSet()
-        {
-            using (var ps = System.Management.Automation.PowerShell.Create())
-            {
-                // Arrange
-                var environment = PowerBIEnvironmentType.OneBox;
-                var tenant = "039db662-19f0-4ca7-869a-3238540f1dd0";
-
-                ps.AddCommand(ProfileTestUtilities.ConnectPowerBIServiceAccountCmdletInfo)
-                    .AddParameter(nameof(ConnectPowerBIServiceAccount.Environment), environment)
-                    .AddParameter(nameof(ConnectPowerBIServiceAccount.Tenant), tenant);
-
-                // Act
-                var results = ps.Invoke();
-
-                // Assert
-                TestUtilities.AssertNoCmdletErrors(ps);
-                Assert.IsTrue(results.Count == 1);
-                Assert.IsTrue(results[0].BaseObject is PowerBIProfile);
-                var profile = results[0].BaseObject as PowerBIProfile;
-                Assert.AreEqual(tenant, profile.TenantId);
-
-                // Disconnect
-                ps.Commands.Clear();
-                ps.AddCommand(ProfileTestUtilities.DisconnectPowerBIServiceAccountCmdletInfo);
-                ps.Invoke();
-            }
         }
 
         [TestMethod]

--- a/src/Modules/Profile/Commands.Profile.Test/ConnectPowerBIServiceAccountTests.cs
+++ b/src/Modules/Profile/Commands.Profile.Test/ConnectPowerBIServiceAccountTests.cs
@@ -90,40 +90,6 @@ namespace Microsoft.PowerBI.Commands.Profile.Test
         }
 
         [TestMethod]
-        [TestCategory("Interactive")]
-        [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
-        public void ConnectPowerBIServiceAccountServiceWithTenantId_UserParameterSet()
-        {
-            using (var ps = System.Management.Automation.PowerShell.Create())
-            {
-                // Arrange
-                var environment = PowerBIEnvironmentType.OneBox;
-                var tenant = "039db662-19f0-4ca7-869a-3238540f1dd0"; // Onebox tenant for ComputeCdsa
-
-#if DEBUG
-                ps.AddCommand(ProfileTestUtilities.ConnectPowerBIServiceAccountCmdletInfo)
-                    .AddParameter(nameof(ConnectPowerBIServiceAccount.Environment), environment)
-                    .AddParameter(nameof(ConnectPowerBIServiceAccount.Tenant), tenant);
-
-                // Act
-                var results = ps.Invoke();
-
-                // Assert
-                TestUtilities.AssertNoCmdletErrors(ps);
-                Assert.IsTrue(results.Count == 1);
-                Assert.IsTrue(results[0].BaseObject is PowerBIProfile);
-                var profile = results[0].BaseObject as PowerBIProfile;
-                Assert.AreEqual(tenant, profile.TenantId);
-
-                // Disconnect
-                ps.Commands.Clear();
-                ps.AddCommand(ProfileTestUtilities.DisconnectPowerBIServiceAccountCmdletInfo);
-                ps.Invoke();
-#endif
-            }
-        }
-
-        [TestMethod]
         public void ConnectPowerBIServiceAccountServiceWithTenantId_PrincipalParameterSet()
         {
             // Arrange

--- a/src/Modules/Profile/Commands.Profile.Test/ConnectPowerBIServiceAccountTests.cs
+++ b/src/Modules/Profile/Commands.Profile.Test/ConnectPowerBIServiceAccountTests.cs
@@ -100,6 +100,7 @@ namespace Microsoft.PowerBI.Commands.Profile.Test
                 var environment = PowerBIEnvironmentType.OneBox;
                 var tenant = "039db662-19f0-4ca7-869a-3238540f1dd0"; // Onebox tenant for ComputeCdsa
 
+#if DEBUG
                 ps.AddCommand(ProfileTestUtilities.ConnectPowerBIServiceAccountCmdletInfo)
                     .AddParameter(nameof(ConnectPowerBIServiceAccount.Environment), environment)
                     .AddParameter(nameof(ConnectPowerBIServiceAccount.Tenant), tenant);
@@ -118,6 +119,7 @@ namespace Microsoft.PowerBI.Commands.Profile.Test
                 ps.Commands.Clear();
                 ps.AddCommand(ProfileTestUtilities.DisconnectPowerBIServiceAccountCmdletInfo);
                 ps.Invoke();
+#endif
             }
         }
 

--- a/src/Modules/Profile/Commands.Profile.Test/ConnectPowerBIServiceAccountTests.cs
+++ b/src/Modules/Profile/Commands.Profile.Test/ConnectPowerBIServiceAccountTests.cs
@@ -54,6 +54,53 @@ namespace Microsoft.PowerBI.Commands.Profile.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        public void ConnectPowerBIServiceAccountServiceWithTenantId_UserParameterSet()
+        {
+            PowerBIEnvironmentType? environment = null;
+            string tenant = null;
+
+            using (var ps = System.Management.Automation.PowerShell.Create())
+            {
+                // Arrange
+                if (environment == null)
+                {
+#if DEBUG
+                    environment = PowerBIEnvironmentType.OneBox;
+                    // onebox tenant for computeCdsa
+                    tenant = "039db662-19f0-4ca7-869a-3238540f1dd0";
+#else
+                    environment = PowerBIEnvironmentType.Public;
+#endif
+                }
+
+                ps.AddCommand(ProfileTestUtilities.ConnectPowerBIServiceAccountCmdletInfo)
+                    .AddParameter(nameof(ConnectPowerBIServiceAccount.Environment), environment)
+                    .AddParameter(nameof(ConnectPowerBIServiceAccount.Tenant), tenant);
+
+                var results = ps.Invoke();
+
+                TestUtilities.AssertNoCmdletErrors(ps);
+                Assert.IsNotNull(results);
+                Assert.IsTrue(results.Count == 1);
+                Assert.IsTrue(results[0].BaseObject is PowerBIProfile);
+                var profile = results[0].BaseObject as PowerBIProfile;
+                Assert.IsNotNull(profile.Environment);
+                Assert.IsNotNull(profile.UserName);
+                if (tenant != null)
+                {
+                    Assert.AreEqual(tenant, profile.TenantId);
+                }
+
+                // Disconnect
+                ps.Commands.Clear();
+                ps.AddCommand(ProfileTestUtilities.DisconnectPowerBIServiceAccountCmdletInfo);
+                ps.Invoke();
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("Interactive")]
+        [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
         public void ConnectPowerBIServiceWithDiscoveryUrl()
         {
             using (var ps = System.Management.Automation.PowerShell.Create())

--- a/src/Modules/Profile/Commands.Profile/ConnectPowerBIServiceAccount.cs
+++ b/src/Modules/Profile/Commands.Profile/ConnectPowerBIServiceAccount.cs
@@ -57,6 +57,8 @@ namespace Microsoft.PowerBI.Commands.Profile
         [Alias("TenantId")]
         [Parameter(ParameterSetName = ServicePrincipalParameterSet, Mandatory = false)]
         [Parameter(ParameterSetName = ServicePrincipalCertificateParameterSet, Mandatory = false)]
+        [Parameter(ParameterSetName = UserAndCredentialPasswordParameterSet, Mandatory = false)]
+        [Parameter(ParameterSetName = UserParameterSet, Mandatory = false)]
         public string Tenant { get; set; }
 
         [Parameter(Mandatory = false)]


### PR DESCRIPTION
Previously, -Tenant could only be used with ServicePrincipal. This PR refactors powershell command to include support for User (therefore allowing B2B users to utilize powershell to connect to their guest user accouns).

### User command without tenant
![WorksWithoutTenant](https://user-images.githubusercontent.com/100881631/210613397-79ae38d1-ce5f-463b-8dde-bb3ab5306009.png)


### User command with tenant
![WorksWithTenant](https://user-images.githubusercontent.com/100881631/210613404-9cd3148a-e9c9-47e2-9810-1a619c1458fa.png)


### B2B User with tenant (email is guest user in onebox tenant)
![WorksWithB2B](https://user-images.githubusercontent.com/100881631/210613427-6f100568-4664-47b6-a897-2f1743c561a7.png)
