### PR TITLE
fixing module versioning for local testing

### DIFF
--- a/scripts/UpdatePSModuleManifest.ps1
+++ b/scripts/UpdatePSModuleManifest.ps1
@@ -32,6 +32,7 @@ param
     [string] $ReleaseNotes
 )
 
+$cleanVersion = $Version -replace '-.*$', ''
 Write-Output "Running $($MyInvocation.MyCommand.Name)"
 $psdFileContent = Get-Content -Path $ModulePath -Raw -ErrorAction Stop
 $updatePsdFile = $false
@@ -52,10 +53,10 @@ else {
 
 # Update ModuleVersion
 $matchRegex = "(?<Front>ModuleVersion = ')(?<ModVersion>.+)(?<Back>')"
-$replaceMatch = '${Front}' + $Version + '${Back}'
+$replaceMatch = '${Front}' + $cleanVersion + '${Back}'
 
-if(($psdFileContent -match $matchRegex) -and ($Matches['ModVersion'] -ne $Version)) {
-    Write-Output "Updating ModuleVersion to: $Version"
+if(($psdFileContent -match $matchRegex) -and ($Matches['ModVersion'] -ne $cleanVersion)) {
+    Write-Output "Updating ModuleVersion to: $cleanVersion"
     $psdFileContent = $psdFileContent -replace $matchRegex, $replaceMatch
     $updatePsdFile = $true
 }


### PR DESCRIPTION
Right now, when a user builds and packs the nugets for this project with the intention of manual testing locally, the powershell modules will not load. This is because Nerdbank versioning always adds a semantic versioning suffix to the package that is used for the nugets, and this same version is used in the UpdatePSModuleManifest.ps1 script to update the PS Module versions. This change removes the semantic versioning suffix from the versions that are passed into the Powershell module files to ensure that users who test locally can run the Powershell commands and load the modules.