### PR TITLE
Enabling code coverage

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -86,7 +86,7 @@ jobs:
           hide_complexity: true
           indicators: true
           output: both
-          thresholds: '50 80'
+          thresholds: '17 80'
 
       - name: Add Coverage PR Comment
         uses: marocchino/sticky-pull-request-comment@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: CodeCoverage
-          path: TestResults/**/coverage.cobertura.xml
+          path: src/**/coverage.cobertura.xml
         if: ${{ always() }}
 
   Publish-Code-Coverage:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -57,6 +57,24 @@ jobs:
           path: TestResults
         if: ${{ always() }}
 
+      - name: Upload Code Coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: CodeCoverage
+          path: TestResults/**/coverage.cobertura.xml
+        if: ${{ always() }}
+
+  Publish-Code-Coverage:
+    runs-on: ubuntu-latest
+    needs: Build
+    if: ${{ always() && needs.Build.result == 'success' }}
+    steps:
+      - name: Download Code Coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: CodeCoverage
+          path: TestResults
+
       - name: Code Coverage Report
         uses: irongut/CodeCoverageSummary@v1.3.0
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -48,7 +48,7 @@ jobs:
         run: dotnet build --no-restore dirs.proj --property:GenerateFullPaths=true --verbosity normal
       
       - name: Test
-        run: dotnet test --no-build --no-restore --filter "TestCategory!=Interactive" --verbosity normal --logger trx --results-directory "TestResults" dirs.proj
+        run: dotnet test --no-build --no-restore --collect "Code Coverage" -p:CollectCoverage=true -p:CoverletOutputFormat=cobertura --filter "TestCategory!=Interactive" --verbosity normal --logger trx --results-directory "TestResults" dirs.proj
       
       - name: Publish Test Results
         uses: actions/upload-artifact@v4
@@ -56,3 +56,23 @@ jobs:
           name: TestResults
           path: TestResults
         if: ${{ always() }}
+
+      - name: Code Coverage Report
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: TestResults/**/coverage.cobertura.xml
+          badge: true
+          fail_below_min: true
+          format: markdown
+          hide_branch_rate: false
+          hide_complexity: true
+          indicators: true
+          output: both
+          thresholds: '50 80'
+
+      - name: Add Coverage PR Comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: github.event_name == 'pull_request'
+        with:
+          recreate: true
+          path: code-coverage-results.md

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -67,6 +67,8 @@ jobs:
   Publish-Code-Coverage:
     runs-on: ubuntu-latest
     needs: Build
+    permissions: 
+      pull-requests: write
     if: ${{ always() && needs.Build.result == 'success' }}
     steps:
       - name: Download Code Coverage

--- a/.gitignore
+++ b/.gitignore
@@ -295,3 +295,6 @@ PkgOut/
 
 # Mono\VSCode development
 .mono/
+
+# Cobertura coverage report
+coverage.cobertura.xml

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -60,7 +60,7 @@ Licensed under the MIT License.
 
   <ItemGroup Condition="'$(MSBuildProjectExtension)' == '.csproj' AND '$(IsTestProject)' == 'true'">
     <!-- Code Coverage for Test projects -->
-    <PackageReference Include="coverlet.msbuild" Version="6.0.4" />
+    <PackageReference Include="coverlet.msbuild" />
   </ItemGroup>
 
   <Import Project="$(RepoTargets)Microsoft.PowerBI.CodeSign.targets" Condition="'$(NoSignTarget)' != 'true' AND '$(MSBuildProjectFile)' != 'dirs.proj'" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -52,6 +52,17 @@ Licensed under the MIT License.
     <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="all" />
   </ItemGroup>
 
+  <!-- Test Project -->
+  <PropertyGroup>
+    <!-- Define a property to check if the project name ends with 'Test' -->
+    <IsTestProject Condition="'$(MSBuildProjectName.EndsWith(`.Test`))'">true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(MSBuildProjectExtension)' == '.csproj' AND '$(IsTestProject)' == 'true'">
+    <!-- Code Coverage for Test projects -->
+    <PackageReference Include="coverlet.msbuild" Version="6.0.4" />
+  </ItemGroup>
+
   <Import Project="$(RepoTargets)Microsoft.PowerBI.CodeSign.targets" Condition="'$(NoSignTarget)' != 'true' AND '$(MSBuildProjectFile)' != 'dirs.proj'" />
   <Import Project="$(RepoTargets)Microsoft.PowerBI.Build.targets" Condition="'$(NoBuildTarget)' != 'true' AND '$(MSBuildProjectFile)' != 'dirs.proj'" />
   <Import Project="$(RepoTargets)Microsoft.PowerBI.Packaging.targets" Condition="'$(NoPackageTarget)' != 'true' AND '$(MSBuildProjectFile)' != 'dirs.proj'" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,5 +29,6 @@
     <PackageVersion Include="SlnGen" Version="2.2.30" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.6.133" />
     <PackageVersion Include="System.IO.Packaging" Version="9.0.4" />
+    <PackageVersion Include="coverlet.msbuild " Version="6.0.4" />
   </ItemGroup>
 </Project>

--- a/src/Common/Common.Authentication/DeviceCodeAuthenticationFactory.cs
+++ b/src/Common/Common.Authentication/DeviceCodeAuthenticationFactory.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Security;
@@ -15,6 +16,7 @@ using Microsoft.PowerBI.Common.Abstractions.Interfaces;
 
 namespace Microsoft.PowerBI.Common.Authentication
 {
+    [ExcludeFromCodeCoverage]
     public class DeviceCodeAuthenticationFactory : IAuthenticationUserFactory
     {
         private enum GetAncestorFlags

--- a/src/Common/Common.Authentication/WindowsAuthenticationFactory.cs
+++ b/src/Common/Common.Authentication/WindowsAuthenticationFactory.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -21,6 +22,7 @@ using Microsoft.PowerBI.Common.Abstractions.Utilities;
 
 namespace Microsoft.PowerBI.Common.Authentication
 {
+    [ExcludeFromCodeCoverage]
     public class WindowsAuthenticationFactory : IAuthenticationUserFactory
     {
         private enum GetAncestorFlags
@@ -59,7 +61,7 @@ namespace Microsoft.PowerBI.Common.Authentication
             else
             {
                 throw new PlatformNotSupportedException("This method is only supported on Windows.");
-            }   
+            }
         }
 
         private IPublicClientApplication AuthApplication;

--- a/src/Modules/Admin/Commands.Admin.Test/AddPowerBIEncryptionKeyTests.cs
+++ b/src/Modules/Admin/Commands.Admin.Test/AddPowerBIEncryptionKeyTests.cs
@@ -4,6 +4,7 @@
  */
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Management.Automation;
 using Microsoft.PowerBI.Commands.Common.Test;
 using Microsoft.PowerBI.Commands.Profile.Test;
@@ -27,6 +28,7 @@ namespace Microsoft.PowerBI.Commands.Admin.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndAddPowerBIEncryptionKey()
         {
             using (var ps = System.Management.Automation.PowerShell.Create())

--- a/src/Modules/Admin/Commands.Admin.Test/GetPowerBIActivityEventTests.cs
+++ b/src/Modules/Admin/Commands.Admin.Test/GetPowerBIActivityEventTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Management.Automation;
 using Microsoft.PowerBI.Commands.Common.Test;
@@ -27,6 +28,7 @@ namespace Microsoft.PowerBI.Commands.Admin.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndGetPowerBIActivityEvents()
         {
             using (var ps = System.Management.Automation.PowerShell.Create())

--- a/src/Modules/Admin/Commands.Admin.Test/GetPowerBIEncryptionKeyTests.cs
+++ b/src/Modules/Admin/Commands.Admin.Test/GetPowerBIEncryptionKeyTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Management.Automation;
 using Microsoft.PowerBI.Commands.Common.Test;
 using Microsoft.PowerBI.Commands.Profile.Test;
@@ -23,6 +24,7 @@ namespace Microsoft.PowerBI.Commands.Admin.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndGetPowerBIEncryptionKey()
         {
             using (var ps = System.Management.Automation.PowerShell.Create())

--- a/src/Modules/Admin/Commands.Admin.Test/GetPowerBIWorkspaceEncryptionStatusTests.cs
+++ b/src/Modules/Admin/Commands.Admin.Test/GetPowerBIWorkspaceEncryptionStatusTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Management.Automation;
 using Microsoft.PowerBI.Commands.Common.Test;
@@ -27,6 +28,7 @@ namespace Microsoft.PowerBI.Commands.Admin.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndGetPowerBIWorkspaceEncryptionStatus()
         {
             using (var ps = System.Management.Automation.PowerShell.Create())

--- a/src/Modules/Admin/Commands.Admin.Test/SwitchPowerBIEncryptionKeyTests.cs
+++ b/src/Modules/Admin/Commands.Admin.Test/SwitchPowerBIEncryptionKeyTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Management.Automation;
 using Microsoft.PowerBI.Commands.Common.Test;
@@ -28,6 +29,7 @@ namespace Microsoft.PowerBI.Commands.Admin.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndRotatePowerBIEncryptionKey()
         {
             using (var ps = System.Management.Automation.PowerShell.Create())

--- a/src/Modules/Capacities/Commands.Capacities.Test/GetPowerBICapacityTests.cs
+++ b/src/Modules/Capacities/Commands.Capacities.Test/GetPowerBICapacityTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Management.Automation;
 using Microsoft.PowerBI.Commands.Common.Test;
@@ -26,6 +27,7 @@ namespace Microsoft.PowerBI.Commands.Capacities.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndGetPowerBICapacityIndividualScopeCmdletInfo()
         {
             using (var ps = System.Management.Automation.PowerShell.Create())
@@ -50,6 +52,7 @@ namespace Microsoft.PowerBI.Commands.Capacities.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndGetPowerBICapacityOrganizationScopeCmdletInfo()
         {
             using (var ps = System.Management.Automation.PowerShell.Create())

--- a/src/Modules/Data/Commands.Data.Test/AddPowerBIDatasetTests.cs
+++ b/src/Modules/Data/Commands.Data.Test/AddPowerBIDatasetTests.cs
@@ -14,6 +14,7 @@ using Microsoft.PowerBI.Common.Api.Datasets;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System.Linq;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.PowerBI.Commands.Data.Test
 {
@@ -28,6 +29,7 @@ namespace Microsoft.PowerBI.Commands.Data.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndAddPowerBIDataset()
         {
             using (var ps = System.Management.Automation.PowerShell.Create())
@@ -51,7 +53,7 @@ namespace Microsoft.PowerBI.Commands.Data.Test
 
                 ps.AddCommand(AddPowerBIDatasetCmdletInfo)
                     .AddParameter(nameof(AddPowerBIDataset.Dataset), dataset.First().BaseObject as Dataset);
-                
+
                 // Act
                 var result = ps.Invoke();
 

--- a/src/Modules/Data/Commands.Data.Test/AddPowerBIRowTests.cs
+++ b/src/Modules/Data/Commands.Data.Test/AddPowerBIRowTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Management.Automation;
 using Microsoft.PowerBI.Commands.Common.Test;
@@ -23,10 +24,11 @@ namespace Microsoft.PowerBI.Commands.Data.Test
         private static CmdletInfo AddPowerBIRowCmdletInfo => new CmdletInfo($"{AddPowerBIRow.CmdletVerb}-{AddPowerBIRow.CmdletName}", typeof(AddPowerBIRow));
         private static CmdletInfo GetPowerBITableCmdletInfo => new CmdletInfo($"{GetPowerBITable.CmdletVerb}-{GetPowerBITable.CmdletName}", typeof(GetPowerBITable));
         private static CmdletInfo GetPowerBIDatasetCmdletInfo => new CmdletInfo($"{GetPowerBIDataset.CmdletVerb}-{GetPowerBIDataset.CmdletName}", typeof(GetPowerBIDataset));
-   
+
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndAddPowerBIRows()
         {
             using (var ps = System.Management.Automation.PowerShell.Create())
@@ -45,7 +47,7 @@ namespace Microsoft.PowerBI.Commands.Data.Test
                 var table = tableResults.First().BaseObject as Table;
 
                 var row1 = new PSObject();
-                row1.Members.Add(new PSNoteProperty("Col1","Data1"));
+                row1.Members.Add(new PSNoteProperty("Col1", "Data1"));
                 row1.Members.Add(new PSNoteProperty("Col2", true));
                 var row2 = new PSObject();
                 row2.Members.Add(new PSNoteProperty("Col1", "Data2"));
@@ -71,6 +73,7 @@ namespace Microsoft.PowerBI.Commands.Data.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndAddPowerBIRowsFromCSV()
         {
             var csvPath = @"path_to_csv_file";
@@ -89,7 +92,7 @@ namespace Microsoft.PowerBI.Commands.Data.Test
 
                 var table = tableResults.First().BaseObject as Table;
 
-                ps.AddCommand("Import-CSV").AddParameter("Path",csvPath);
+                ps.AddCommand("Import-CSV").AddParameter("Path", csvPath);
                 var rows = ps.Invoke();
                 ps.Commands.Clear();
                 ps.AddCommand(AddPowerBIRowCmdletInfo)
@@ -110,8 +113,9 @@ namespace Microsoft.PowerBI.Commands.Data.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndAddPowerBIRowsFromArray()
-        {           
+        {
             using (var ps = System.Management.Automation.PowerShell.Create())
             {
                 // Arrange

--- a/src/Modules/Data/Commands.Data.Test/ExportPowerBIDataflowTests.cs
+++ b/src/Modules/Data/Commands.Data.Test/ExportPowerBIDataflowTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Management.Automation;
@@ -29,6 +30,7 @@ namespace Microsoft.PowerBI.Commands.Data.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndExportPowerBIDataflowOrganizationScope_ByDataflowId()
         {
             /*
@@ -82,6 +84,7 @@ namespace Microsoft.PowerBI.Commands.Data.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndExportPowerBIDataflowOrganizationScope_ByDataflow()
         {
             /*

--- a/src/Modules/Data/Commands.Data.Test/GetPowerBIDataflowDatasourceTests.cs
+++ b/src/Modules/Data/Commands.Data.Test/GetPowerBIDataflowDatasourceTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Management.Automation;
 using System.Text;
@@ -27,6 +28,7 @@ namespace Microsoft.PowerBI.Commands.Data.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndGetPowerBIDataflowDatasourceOrganizationScope()
         {
             /*
@@ -44,7 +46,7 @@ namespace Microsoft.PowerBI.Commands.Data.Test
                 TestUtilities.AssertNoCmdletErrors(ps);
                 ps.Commands.Clear();
 
-                if(!existingDataflows.Any())
+                if (!existingDataflows.Any())
                 {
                     Assert.Inconclusive("No dataflows returned. Verify you have dataflows under your logged in user.");
                 }
@@ -119,6 +121,7 @@ namespace Microsoft.PowerBI.Commands.Data.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndPipingDataflowIntoGetPowerBIDataflowDatasourceOrganizationScope()
         {
             /*

--- a/src/Modules/Data/Commands.Data.Test/GetPowerBIDataflowTests.cs
+++ b/src/Modules/Data/Commands.Data.Test/GetPowerBIDataflowTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Management.Automation;
 using Microsoft.PowerBI.Commands.Common.Test;
 using Microsoft.PowerBI.Commands.Profile.Test;
@@ -24,6 +25,7 @@ namespace Microsoft.PowerBI.Commands.Data.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndGetPowerBIDataflowOrganizationScope()
         {
             using (var ps = System.Management.Automation.PowerShell.Create())

--- a/src/Modules/Data/Commands.Data.Test/GetPowerBIDatasetTests.cs
+++ b/src/Modules/Data/Commands.Data.Test/GetPowerBIDatasetTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Management.Automation;
 using Microsoft.PowerBI.Commands.Common.Test;
 using Microsoft.PowerBI.Commands.Profile.Test;
@@ -24,6 +25,7 @@ namespace Microsoft.PowerBI.Commands.Data
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndGetPowerBIDatasetOrganizationScope()
         {
             using (var ps = System.Management.Automation.PowerShell.Create())

--- a/src/Modules/Data/Commands.Data.Test/GetPowerBIDatasourceTests.cs
+++ b/src/Modules/Data/Commands.Data.Test/GetPowerBIDatasourceTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Management.Automation;
 using System.Text;
@@ -27,6 +28,7 @@ namespace Microsoft.PowerBI.Commands.Data.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndGetPowerBIDatasourceIndividualScope()
         {
             /*
@@ -43,7 +45,7 @@ namespace Microsoft.PowerBI.Commands.Data.Test
                 TestUtilities.AssertNoCmdletErrors(ps);
                 ps.Commands.Clear();
 
-                if(!existingDatasets.Any())
+                if (!existingDatasets.Any())
                 {
                     Assert.Inconclusive("No datasets returned. Verify you have datasets under your logged in user.");
                 }
@@ -111,6 +113,7 @@ namespace Microsoft.PowerBI.Commands.Data.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndPipingDatasetIntoGetPowerBIDatasourceIndividualScope()
         {
             /*

--- a/src/Modules/Data/Commands.Data.Test/GetPowerBITableTests.cs
+++ b/src/Modules/Data/Commands.Data.Test/GetPowerBITableTests.cs
@@ -14,6 +14,7 @@ using Microsoft.PowerBI.Common.Api.Datasets;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System.Linq;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.PowerBI.Commands.Data.Test
 {
@@ -26,6 +27,7 @@ namespace Microsoft.PowerBI.Commands.Data.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndGetPowerBITable_DatasetIdParameterSetName()
         {
             using (var ps = System.Management.Automation.PowerShell.Create())
@@ -39,7 +41,7 @@ namespace Microsoft.PowerBI.Commands.Data.Test
                 ps.AddCommand(GetPowerBITableCmdletInfo)
                     .AddParameter(nameof(GetPowerBITable.DatasetId), datasetId)
                     .AddParameter(nameof(GetPowerBITable.Name), "Product");
-                
+
                 // Act
                 var results = ps.Invoke();
 
@@ -56,6 +58,7 @@ namespace Microsoft.PowerBI.Commands.Data.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndGetPowerBITable_DatasetParameterSetName()
         {
             using (var ps = System.Management.Automation.PowerShell.Create())

--- a/src/Modules/Data/Commands.Data.Test/RemovePowerBIRowTests.cs
+++ b/src/Modules/Data/Commands.Data.Test/RemovePowerBIRowTests.cs
@@ -4,6 +4,7 @@
  */
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Management.Automation;
 using Microsoft.PowerBI.Commands.Common.Test;
@@ -22,10 +23,11 @@ namespace Microsoft.PowerBI.Commands.Data.Test
         private static CmdletInfo RemovePowerBIRowCmdletInfo => new CmdletInfo($"{RemovePowerBIRow.CmdletVerb}-{RemovePowerBIRow.CmdletName}", typeof(RemovePowerBIRow));
         private static CmdletInfo GetPowerBITableCmdletInfo => new CmdletInfo($"{GetPowerBITable.CmdletVerb}-{GetPowerBITable.CmdletName}", typeof(GetPowerBITable));
         private static CmdletInfo GetPowerBIDatasetCmdletInfo => new CmdletInfo($"{GetPowerBIDataset.CmdletVerb}-{GetPowerBIDataset.CmdletName}", typeof(GetPowerBIDataset));
-   
+
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndRemovePowerBIRows()
         {
             using (var ps = System.Management.Automation.PowerShell.Create())

--- a/src/Modules/Data/Commands.Data.Test/SetPowerBIDatasetTests.cs
+++ b/src/Modules/Data/Commands.Data.Test/SetPowerBIDatasetTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Management.Automation;
 using Microsoft.PowerBI.Commands.Common.Test;
@@ -26,6 +27,7 @@ namespace Microsoft.PowerBI.Commands.Data.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndSetPowerBIDataset()
         {
             using (var ps = System.Management.Automation.PowerShell.Create())

--- a/src/Modules/Data/Commands.Data.Test/SetPowerBITableTests.cs
+++ b/src/Modules/Data/Commands.Data.Test/SetPowerBITableTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Management.Automation;
 using Microsoft.PowerBI.Commands.Common.Test;
@@ -23,10 +24,11 @@ namespace Microsoft.PowerBI.Commands.Data.Test
         private static CmdletInfo SetPowerBITestCmdletInfo => new CmdletInfo($"{SetPowerBITable.CmdletVerb}-{SetPowerBITable.CmdletName}", typeof(SetPowerBITable));
         private static CmdletInfo GetPowerBITableCmdletInfo => new CmdletInfo($"{GetPowerBITable.CmdletVerb}-{GetPowerBITable.CmdletName}", typeof(GetPowerBITable));
         private static CmdletInfo GetPowerBIDatasetCmdletInfo => new CmdletInfo($"{GetPowerBIDataset.CmdletVerb}-{GetPowerBIDataset.CmdletName}", typeof(GetPowerBIDataset));
-   
+
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndSetPowerBIDataset()
         {
             using (var ps = System.Management.Automation.PowerShell.Create())

--- a/src/Modules/Profile/Commands.Profile.Test/ConnectPowerBIServiceAccountTests.cs
+++ b/src/Modules/Profile/Commands.Profile.Test/ConnectPowerBIServiceAccountTests.cs
@@ -4,6 +4,7 @@
  */
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Management.Automation;
 using System.Security;
 using Microsoft.PowerBI.Commands.Common.Test;
@@ -18,6 +19,7 @@ namespace Microsoft.PowerBI.Commands.Profile.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndInteractiveLogin()
         {
             using (var ps = System.Management.Automation.PowerShell.Create())
@@ -54,6 +56,7 @@ namespace Microsoft.PowerBI.Commands.Profile.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void ConnectPowerBIServiceAccountServiceWithTenantId_UserParameterSet()
         {
             PowerBIEnvironmentType? environment = null;
@@ -101,6 +104,7 @@ namespace Microsoft.PowerBI.Commands.Profile.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void ConnectPowerBIServiceWithDiscoveryUrl()
         {
             using (var ps = System.Management.Automation.PowerShell.Create())

--- a/src/Modules/Profile/Commands.Profile.Test/DisconnectPowerBIServiceAccountTests.cs
+++ b/src/Modules/Profile/Commands.Profile.Test/DisconnectPowerBIServiceAccountTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Management.Automation;
 using System.Text;
 using Microsoft.PowerBI.Commands.Common;
@@ -19,6 +20,7 @@ namespace Microsoft.PowerBI.Commands.Profile.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void LogoutNoLoginTest()
         {
             using (var ps = System.Management.Automation.PowerShell.Create())

--- a/src/Modules/Profile/Commands.Profile.Test/InvokePowerBIRestMethodTests.cs
+++ b/src/Modules/Profile/Commands.Profile.Test/InvokePowerBIRestMethodTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Management.Automation;
 using System.Net.Http;
@@ -23,6 +24,7 @@ namespace Microsoft.PowerBI.Commands.Profile.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndInvokePowerBIRestMethodWithOutFile()
         {
             using (var ps = System.Management.Automation.PowerShell.Create())

--- a/src/Modules/Reports/Commands.Reports.Test/CopyPowerBIReportTests.cs
+++ b/src/Modules/Reports/Commands.Reports.Test/CopyPowerBIReportTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Management.Automation;
 using Microsoft.PowerBI.Commands.Common.Test;
@@ -27,6 +28,7 @@ namespace Commands.Reports.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndCopyReportIndividualScope()
         {
             using (var ps = PowerShell.Create())
@@ -48,6 +50,7 @@ namespace Commands.Reports.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndCopyReportToMyWorkspaceIndividualScope()
         {
             using (var ps = PowerShell.Create())

--- a/src/Modules/Reports/Commands.Reports.Test/CopyPowerBITileTests.cs
+++ b/src/Modules/Reports/Commands.Reports.Test/CopyPowerBITileTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Management.Automation;
 using Microsoft.PowerBI.Commands.Common.Test;
@@ -27,6 +28,7 @@ namespace Commands.Reports.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndCopyTileIndividualScope()
         {
             using (var ps = PowerShell.Create())

--- a/src/Modules/Reports/Commands.Reports.Test/GetPowerBIReportTests.cs
+++ b/src/Modules/Reports/Commands.Reports.Test/GetPowerBIReportTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Management.Automation;
 using Microsoft.PowerBI.Commands.Common.Test;
@@ -25,6 +26,7 @@ namespace Commands.Reports.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndGetReportsIndividualScope()
         {
             using (var ps = PowerShell.Create())

--- a/src/Modules/Reports/Commands.Reports.Test/NewPowerBIDashboardTests.cs
+++ b/src/Modules/Reports/Commands.Reports.Test/NewPowerBIDashboardTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Management.Automation;
 using Microsoft.PowerBI.Commands.Common.Test;
@@ -27,6 +28,7 @@ namespace Commands.Reports.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndNewDashboardIndividualScope()
         {
             using (var ps = PowerShell.Create())
@@ -48,6 +50,7 @@ namespace Commands.Reports.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndNewDashboardInMyWorkspaceIndividualScope()
         {
             using (var ps = PowerShell.Create())

--- a/src/Modules/Reports/Commands.Reports.Test/NewPowerBIReportTests.cs
+++ b/src/Modules/Reports/Commands.Reports.Test/NewPowerBIReportTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Management.Automation;
 using Microsoft.PowerBI.Commands.Common.Test;
@@ -31,6 +32,7 @@ namespace Commands.Reports.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndNewReportIndividualScope()
         {
             using (var ps = PowerShell.Create())
@@ -52,6 +54,7 @@ namespace Commands.Reports.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndNewReportWorkspace()
         {
             using (var ps = PowerShell.Create())
@@ -76,6 +79,7 @@ namespace Commands.Reports.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndNewReportWorkspaceWithoutName()
         {
             using (var ps = PowerShell.Create())
@@ -99,6 +103,7 @@ namespace Commands.Reports.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndNewReportWorkspaceWithMultipleReports()
         {
             Guid expectedReportId;

--- a/src/Modules/Reports/Commands.Reports.Test/RemovePowerBIReportTests.cs
+++ b/src/Modules/Reports/Commands.Reports.Test/RemovePowerBIReportTests.cs
@@ -4,6 +4,7 @@
  */
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Management.Automation;
 using Microsoft.PowerBI.Commands.Common.Test;
@@ -22,18 +23,19 @@ namespace Commands.Reports.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndRemovePowerBIReport()
         {
             using (var ps = System.Management.Automation.PowerShell.Create())
             {
-                ProfileTestUtilities.ConnectToPowerBI(ps,PowerBIEnvironmentType.Public); // If login is needed
+                ProfileTestUtilities.ConnectToPowerBI(ps, PowerBIEnvironmentType.Public); // If login is needed
                 ps.AddCommand(new CmdletInfo($"{RemovePowerBIReport.CmdletVerb}-{RemovePowerBIReport.CmdletName}", typeof(RemovePowerBIReport)));
                 ps.AddParameter("Id", "fce8abb5-192b-4be2-b75e-b43bb93d8943");
                 ps.AddParameter("WorkspaceId", "kjsdfjs;sf");
                 var result = ps.Invoke();
 
                 // Add asserts to verify
-                
+
                 TestUtilities.AssertNoCmdletErrors(ps);
             }
         }

--- a/src/Modules/Workspaces/Commands.Workspaces.Test/AddPowerBIWorkspaceUserTests.cs
+++ b/src/Modules/Workspaces/Commands.Workspaces.Test/AddPowerBIWorkspaceUserTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Management.Automation;
 using Microsoft.PowerBI.Commands.Common.Test;
@@ -25,6 +26,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndAddPowerBIWorkspaceUserOrganizationScope()
         {
             using (var ps = System.Management.Automation.PowerShell.Create())
@@ -59,6 +61,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndAddPowerBIWorkspaceUserIndividualScope()
         {
             // TODO: Note that unlike the admin APIs, this API will throw an error when attempting to add a user that already has access to the workspace
@@ -74,7 +77,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
                 var parameters = new Dictionary<string, object>()
                 {
                     { nameof(AddPowerBIWorkspaceUser.Scope), PowerBIUserScope.Individual },
-                    { nameof(AddPowerBIWorkspaceUser.Id), workspace.Id }, 
+                    { nameof(AddPowerBIWorkspaceUser.Id), workspace.Id },
                     { nameof(AddPowerBIWorkspaceUser.UserPrincipalName), emailAddress },
                     { nameof(AddPowerBIWorkspaceUser.AccessRight), WorkspaceUserAccessRight.Admin }
                 };
@@ -93,6 +96,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndAddPowerBIWorkspaceUser_ExplicitPrincipalType()
         {
             // Set this to the identifier of the object (App, Group, or User) you want to add to the workspace.
@@ -119,7 +123,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
 
                 var parameters = new Dictionary<string, object>()
                 {
-                    { nameof(AddPowerBIWorkspaceUser.Id), workspaceId }, 
+                    { nameof(AddPowerBIWorkspaceUser.Id), workspaceId },
                     { nameof(AddPowerBIWorkspaceUser.PrincipalType), PrincipalType },
                     { nameof(AddPowerBIWorkspaceUser.Identifier), ObjectId },
                     { nameof(AddPowerBIWorkspaceUser.AccessRight), WorkspaceUserAccessRight.Contributor }

--- a/src/Modules/Workspaces/Commands.Workspaces.Test/GetPowerBIWorkspaceTests.cs
+++ b/src/Modules/Workspaces/Commands.Workspaces.Test/GetPowerBIWorkspaceTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Management.Automation;
 using Microsoft.PowerBI.Api.V2.Models;
@@ -24,6 +25,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndGetWorkspacesOrganizationScope()
         {
             /*
@@ -52,6 +54,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndGetWorkspacesAllAndOrganizationScope()
         {
             /*
@@ -86,6 +89,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndGetWorkspacesAllAndIndividualScope()
         {
             /*
@@ -120,6 +124,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndGetWorkspacesAllAndOrganizationScopeAndUser()
         {
             /*
@@ -160,6 +165,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndGetWorkspacesAllAndOrganizationScopeAndIncludeAll()
         {
             /*
@@ -200,6 +206,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndGetWorkspacesIndividualScope()
         {
             /*
@@ -228,6 +235,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndGetWorkspacesOrganizationScopeAndFirst()
         {
             /*
@@ -262,6 +270,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndGetWorkspacesIndividualScopeAndFirst()
         {
             /*
@@ -296,6 +305,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndGetWorkspacesOrganizationScopeAndFilter()
         {
             /*
@@ -341,6 +351,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndGetWorkspacesIndividualScopeAndFilter()
         {
             /*
@@ -386,6 +397,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndGetWorkspacesOrganizationScopeAndUser()
         {
             /*
@@ -431,6 +443,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndGetWorkspacesOrganizationScopeAndDeleted()
         {
             /*

--- a/src/Modules/Workspaces/Commands.Workspaces.Test/NewPowerBIWorkspaceTests.cs
+++ b/src/Modules/Workspaces/Commands.Workspaces.Test/NewPowerBIWorkspaceTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Management.Automation;
 using Microsoft.PowerBI.Commands.Common.Test;
@@ -25,6 +26,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndNewPowerBIWorkspaceTest()
         {
             using (var ps = System.Management.Automation.PowerShell.Create())

--- a/src/Modules/Workspaces/Commands.Workspaces.Test/RemovePowerBIWorkspaceUserTests.cs
+++ b/src/Modules/Workspaces/Commands.Workspaces.Test/RemovePowerBIWorkspaceUserTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Management.Automation;
 using Microsoft.PowerBI.Commands.Common.Test;
@@ -25,6 +26,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndRemovePowerBIWorkspaceUserOrganizationScope()
         {
             using (var ps = System.Management.Automation.PowerShell.Create())
@@ -56,6 +58,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndRemovePowerBIWorkspaceUserIndividualScope()
         {
             // TODO: Note that unlike the admin APIs, this API will throw an error when attempting to remove a user that does not have access to the workspace
@@ -71,7 +74,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
                 var parameters = new Dictionary<string, object>()
                 {
                     { nameof(RemovePowerBIWorkspaceUser.Scope), PowerBIUserScope.Individual },
-                    { nameof(RemovePowerBIWorkspaceUser.Id), workspace.Id }, 
+                    { nameof(RemovePowerBIWorkspaceUser.Id), workspace.Id },
                     { nameof(RemovePowerBIWorkspaceUser.UserPrincipalName), emailAddress},
                 };
                 ps.AddCommand(Cmdlet).AddParameters(parameters);

--- a/src/Modules/Workspaces/Commands.Workspaces.Test/RestorePowerBIWorkspaceTests.cs
+++ b/src/Modules/Workspaces/Commands.Workspaces.Test/RestorePowerBIWorkspaceTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Management.Automation;
 using Microsoft.PowerBI.Commands.Common.Test;
@@ -25,6 +26,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndRestoreWorkspaceOrganizationScopePropertiesParameterSet()
         {
             /*
@@ -64,6 +66,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndRestoreWorkspaceOrganizationScopeWorkspaceParameterSet()
         {
             /*
@@ -103,6 +106,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndRestoreWorkspaceIndividualScope()
         {
             using (var ps = System.Management.Automation.PowerShell.Create())

--- a/src/Modules/Workspaces/Commands.Workspaces.Test/SetPowerBIWorkspaceTests.cs
+++ b/src/Modules/Workspaces/Commands.Workspaces.Test/SetPowerBIWorkspaceTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Management.Automation;
 using Microsoft.PowerBI.Commands.Common.Test;
 using Microsoft.PowerBI.Commands.Profile.Test;
@@ -24,6 +25,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndSetWorkspaceOrganizationScopePropertiesParameterSet()
         {
             using (var ps = System.Management.Automation.PowerShell.Create())
@@ -58,6 +60,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndSetWorkspaceOrganizationScopeWorkspaceParameterSet()
         {
             using (var ps = System.Management.Automation.PowerShell.Create())
@@ -92,6 +95,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndSetWorkspaceOrganizationScopeCapacityParameterSet()
         {
             using (var ps = System.Management.Automation.PowerShell.Create())
@@ -122,6 +126,7 @@ namespace Microsoft.PowerBI.Commands.Workspaces.Test
         [TestMethod]
         [TestCategory("Interactive")]
         [TestCategory("SkipWhenLiveUnitTesting")] // Ignore for Live Unit Testing
+        [ExcludeFromCodeCoverage]
         public void EndToEndSetWorkspaceIndividualScope()
         {
             using (var ps = System.Management.Automation.PowerShell.Create())


### PR DESCRIPTION
Enabling Code Coverage for dotnet test.

Adding code coverage report using: 
https://github.com/marketplace/actions/code-coverage-summary

Needs to generate a cobertura result, using coverlet.msbuild - https://www.nuget.org/packages/coverlet.msbuild#readme-body-tab

Using Sticky Pull Request commenting:
https://github.com/marketplace/actions/sticky-pull-request-comment

Other references:
- https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-test?tabs=dotnet-test-with-vstest
- https://learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-extensions-code-coverage#microsoft-code-coverage
- https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-code-coverage?tabs=windows

Good examples: 
- https://josh-ops.com/posts/github-code-coverage/
- https://www.meziantou.net/computing-code-coverage-for-a-dotnet-project.htm

General testing in GitHub: 
- https://learn.microsoft.com/en-us/dotnet/devops/dotnet-test-github-action
- https://docs.github.com/en/actions/use-cases-and-examples/building-and-testing/building-and-testing-net

Future work, consider switching to mstestV3 - https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-sdk

https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-migration-from-v1-to-v3