### PR TITLE
Fix Code Coverage status for forked PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Add Coverage PR Comment
         uses: marocchino/sticky-pull-request-comment@v2
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
         with:
           recreate: true
           path: code-coverage-results.md


### PR DESCRIPTION
Commenting on PR status for forked repos won't work. Could create a repo secret and use that to comment but that secret can only live for 90 days and needs to constantly be rotated.

Otherwise we would have to setup a GitHub app and a Key Vault and use that to generate a token.

But the easiest way to deal with this, just comment on PRs that are not forked. 

That means for forked PRs, you have to manually check coverage looking at PR action.